### PR TITLE
Replace ffi package with ffi-napi

### DIFF
--- a/TSS.JS/package.json
+++ b/TSS.JS/package.json
@@ -6,9 +6,13 @@
   "types": "./lib/index.d.ts",
   "author": "Microsoft Corporation",
   "license": "MIT",
-  "keywords": [ "TPM", "TPM 2.0", "TSS" ],
+  "keywords": [
+    "TPM",
+    "TPM 2.0",
+    "TSS"
+  ],
   "optionalDependencies": {
-    "ffi": "^2.2.0",
+    "ffi-napi": "^2.4.3",
     "net": "^1.0.2",
     "ref": "^1.3.5",
     "ref-array": "^1.2.0",

--- a/TSS.JS/src/TpmDevice.ts
+++ b/TSS.JS/src/TpmDevice.ts
@@ -135,7 +135,7 @@ export class TpmTbsDevice implements TpmDevice
     ) {
         if (TpmTbsDevice.ffi == null)
         {
-            TpmTbsDevice.ffi = require('ffi');
+            TpmTbsDevice.ffi = require('ffi-napi');
             TpmTbsDevice.ref = require('ref');
             TpmTbsDevice.Struct = require('ref-struct');
             TpmTbsDevice.ArrayType = require('ref-array')


### PR DESCRIPTION
This PR replaces the unmaintained ffi library with a more-maintained ffi-napi version. This version claims support down to Node 6 so should meet our compatibility goals there.

I've tested that this builds on various flavors of node 10. This should be tested with downlevel versions of Node on Windows.

I have not tested functionality, although the package claims to be a drop-in replacement.