### PR TITLE
Fix #34 - Remove SetDllDirectory native import for non-UWP

### DIFF
--- a/TSS.NET/TSS.Net/TbsDevice.cs
+++ b/TSS.NET/TSS.Net/TbsDevice.cs
@@ -325,9 +325,11 @@ namespace Tpm2Lib
     {
         public class NativeMethods
         {
+#if WINDOWS_UWP
             // helper to find the TPM
             [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             public static extern bool SetDllDirectory(string lpPathName);
+#endif
 
 #region TpmExports
 


### PR DESCRIPTION
Fix for #34 

This removes the `SetDllDirectory` kernal32 native import for non-UWP. This was only being used for the UWP configuration and caused projects that included this package to fail the Windows Store app review (and publish). 

This was tested with a bare-bones UWP app (with the non-UWP TSS configuration) and now passes.