### PR TITLE
Add an UnselectPcr function.

### DIFF
--- a/TSS.NET/TSS.Net/TpmCustomDefs.cs
+++ b/TSS.NET/TSS.Net/TpmCustomDefs.cs
@@ -954,7 +954,7 @@ namespace Tpm2Lib
             Init();
             int byteNum = (int)pcrNumber / 8;
             var bitNum = (int)(pcrNumber % 8);
-            pcrSelect[byteNum] &= (byte)(0 << bitNum);
+            pcrSelect[byteNum] &= (byte)~(1 << bitNum);
         }
 
         public void UnselectPcrs(uint[] pcrNumbers)

--- a/TSS.NET/TSS.Net/TpmCustomDefs.cs
+++ b/TSS.NET/TSS.Net/TpmCustomDefs.cs
@@ -941,12 +941,28 @@ namespace Tpm2Lib
             pcrSelect[byteNum] |= (byte)(1 << bitNum);
         }
 
+        public void SelectPcrs(uint[] pcrNumbers)
+        {
+            foreach (uint pcrNumber in pcrNumbers)
+            {
+                SelectPcr(pcrNumber);
+            }
+        }
+
         public void UnselectPcr(uint pcrNumber)
         {
             Init();
             int byteNum = (int)pcrNumber / 8;
             var bitNum = (int)(pcrNumber % 8);
             pcrSelect[byteNum] &= (byte)(0 << bitNum);
+        }
+
+        public void UnselectPcrs(uint[] pcrNumbers)
+        {
+            foreach(uint pcrNumber in pcrNumbers)
+            {
+                UnselectPcr(pcrNumber);
+            }
         }
 
         public bool IsPcrSelected(uint pcrNumber)

--- a/TSS.NET/TSS.Net/TpmCustomDefs.cs
+++ b/TSS.NET/TSS.Net/TpmCustomDefs.cs
@@ -941,6 +941,14 @@ namespace Tpm2Lib
             pcrSelect[byteNum] |= (byte)(1 << bitNum);
         }
 
+        public void UnselectPcr(uint pcrNumber)
+        {
+            Init();
+            int byteNum = (int)pcrNumber / 8;
+            var bitNum = (int)(pcrNumber % 8);
+            pcrSelect[byteNum] &= (byte)(0 << bitNum);
+        }
+
         public bool IsPcrSelected(uint pcrNumber)
         {
             Init();


### PR DESCRIPTION
# Use Case
In Attack Surface Analyzer we are gathering all the PCR banks available.  `PcrRead` may return only a subset of banks selected, so we need to check to see if there is a residual set of PCRs which must be collected.  Rather than building a new PcrSelection that contains the new set, I want to reuse the existing PcrSelection like below.

Current:
```csharp
var pcrsRead = valRead.GetSelectedPcrs();
var newPcrs = pcr.GetSelectedPcrs().Except(pcrsRead);
pcrs[0] = new PcrSelection(tpmAlgId, 24);
foreach(var newPcr in newPcrs)
{
    pcrs[0].SelectPcr(newPcr);
}
```
After PR:
```csharp
var pcrsRead = valRead.GetSelectedPcrs();
pcrs[0].UnselectPcrs(pcrsRead);
```
More Code Context:
```csharp
do
{
    tpm.PcrRead(pcrs, out PcrSelection[] valsRead, out Tpm2bDigest[] values);

    if (values.Length == 0)
    {
        break;
    }

    var pcrsRead = valsRead[0].GetSelectedPcrs();

    // This PR Adds this method
    pcrs[0].UnselectPcrs(pcrsRead);

    for (int i = 0; i < values.Length; i++)
    {
        output.Add((tpmAlgId, pcrsRead[i]), values[i].buffer);
    }
} while (pcrs[0].GetSelectedPcrs().Length > 0);
```