### PR TITLE
Use getter instead of property access

### DIFF
--- a/TSS.CPP/Src/Tpm2.cpp
+++ b/TSS.CPP/Src/Tpm2.cpp
@@ -807,11 +807,11 @@ void Tpm2::PrepareParmEncryptionSessions()
     // This precludes encryption sessions removal by malware.
     if (DecSession && DecSession != Sessions[0])
     {
-        NonceTpmDec = DecSession->NonceTpm;
+        NonceTpmDec = DecSession->GetNonceTpm();
     }
     if (EncSession && EncSession != Sessions[0] && EncSession != DecSession)
     {
-        NonceTpmEnc = EncSession->NonceTpm;
+        NonceTpmEnc = EncSession->GetNonceTpm();
     }
 }
 


### PR DESCRIPTION
This will allow better encapsulation and reduce the coupling between the TPM and AUTH_SESSION classes.