### PR TITLE
Reverted another call from TkHashCheck to TpmHashCheck.Null().

### DIFF
--- a/TSS.NET/Samples/Signing/Program.cs
+++ b/TSS.NET/Samples/Signing/Program.cs
@@ -208,7 +208,7 @@ namespace Signing
                 var signature = tpm[keyAuth].Sign(keyHandle,            // Handle of signing key
                                                   digestToSign,         // Data to sign
                                                   null,                 // Use key's scheme
-                                                  new TkHashcheck()) as SignatureRsassa;
+                                                 TpmHashCheck.Null()) as SignatureRsassa;
                 // 
                 // Print the signature.
                 // 


### PR DESCRIPTION
Reverted the call from TkHashCheck to TpmHashCheck.Null() for the 'Signing' sample as well.
See de954cf644b46cb636106132afe95d1e5a3b5e8a

I prepared this fork with a commit for the updated "Sample/Signing" but if it only causes you more trouble to clean-up once the "new TkHashCheck()" is working properly, maybe I should revert this change and just add a comment in code so that passerbys could make the fix themselves, if they need it?

Thanks again for the help via mail (next time I will open an Issue in GitHub first).