### PR TITLE
Pass TBS errors up to test infrastructure

### DIFF
--- a/TSS.NET/TSS.Net/TbsDevice.cs
+++ b/TSS.NET/TSS.Net/TbsDevice.cs
@@ -135,10 +135,6 @@ namespace Tpm2Lib
                 }
                 result = TpmRc.TbsUnknownError;
             }
-            else if (tbsRes == TbsWrapper.TBS_RESULT.BAD_PARAMETER)
-            {
-                result = TpmRc.TbsBadParameter;
-            }
             else
             { 
                 result = (TpmRc)tbsRes;

--- a/TSS.NET/TSS.Net/TbsDevice.cs
+++ b/TSS.NET/TSS.Net/TbsDevice.cs
@@ -125,7 +125,6 @@ namespace Tpm2Lib
                                      (uint)inBuf.Length,
                                      resultBuf,
                                      ref resultByteCount);
-            string errMsg;
             if (tbsRes == TbsWrapper.TBS_RESULT.SUCCESS)
             {
                 if (resultByteCount != 0)
@@ -135,11 +134,14 @@ namespace Tpm2Lib
                     return;
                 }
                 result = TpmRc.TbsUnknownError;
-                errMsg = Globs.GetResourceString("SubmitError2");
+            }
+            else if (tbsRes == TbsWrapper.TBS_RESULT.BAD_PARAMETER)
+            {
+                result = TpmRc.TbsBadParameter;
             }
             else
-            {
-                errMsg = new Win32Exception((int)result).Message;
+            { 
+                result = (TpmRc)tbsRes;
             }
 
             outBuf = TpmErrorHelpers.BuildErrorResponseBuffer(result);


### PR DESCRIPTION
Errors from TBS are currently ignored, and a reply is built with a success code instead of the failure code:
> 80 01 00 00 00 0a 00 00 00 00

This change will make it so that TBS errors beyond `TbsUnknownError` are instead propagated inside of the faked TPM response. For example, TBS_BAD_PARAMETER will now build the error reply:
> 80 01 00 00 00 0a 80 28 40 02

This will allow tests to expect TBS errors, e.g.
> some_Tpm2_classObject._ExpectError(TpmRc.TbsBadParameter).SomeTpmCommand(argumentsTbsDoesNotLike);

Additionally, I removed `errMsg` from this function, as it is not being used.