### PR TITLE
Add new TbsBlocked flag in Special Attributes

### DIFF
--- a/Tpm2Tester/README.md
+++ b/Tpm2Tester/README.md
@@ -378,7 +378,7 @@ Fuzzing options:
   breakCmd - Command, to which -fuzzcount applies
   breakCount - Number of fuzzed commands to skip before -fuzzcount applies
 
-Miscelaneous options:
+Miscellaneous options:
   parseIn       Interpret byte-string as TPM command
   parseOut      Interpret byte-string as a TPM response
   tpmInfo       Dump TPM information and exit

--- a/Tpm2Tester/TestSubstrate/TestAttributes.cs
+++ b/Tpm2Tester/TestSubstrate/TestAttributes.cs
@@ -41,7 +41,7 @@ namespace Tpm2Tester
 
     // Special Attributes affect how tests are run, and whether a test will run on a particular device
     // NotThreadSafe, TpmCfg.PowerControl
-    // Which auth values are needed (OnwerAuth, PrivacyAuth, PlatformAuth, LocoutAuth)
+    // Which auth values are needed (OwnerAuth, PrivacyAuth, PlatformAuth, LockoutAuth)
     // The major subsystem tested (NV, Crypto, etc.)
     [Flags]
     public enum Special
@@ -84,7 +84,10 @@ namespace Tpm2Tester
         Lockout = 0x400,
 
         // Test needs to be able to turn TPM NV on/off
-        NvControl = 0x800
+        NvControl = 0x800,
+
+        // Uses commands that are blocked by TBS (ContextLoad/Save)
+        TbsBlocked = 0x1000,
     } // enum Special
 
     // A category reflects a TPM subsystem or functionality subset targeted by the test

--- a/Tpm2Tester/TestSubstrate/TestCmdLine.cs
+++ b/Tpm2Tester/TestSubstrate/TestCmdLine.cs
@@ -388,7 +388,7 @@ namespace Tpm2Tester
                     return cl.NextIntParam(ref cl.Target.BreakCount);
                 }),
 
-            new Option("tpmInfo", "Miscelaneous", "Dumps TPM information",
+            new Option("tpmInfo", "Miscellaneous", "Dumps TPM information",
                 (TesterCmdLine cl) =>
                 {
                     cl.TestCfg.DumpTpmInfo = true;
@@ -396,7 +396,7 @@ namespace Tpm2Tester
                     cl.TestCfg.Verbose = false;
                     return true;
                 }),
-            new Option("parseIn", "Miscelaneous", "Interpret byte-string as TPM command",
+            new Option("parseIn", "Miscellaneous", "Interpret byte-string as TPM command",
                 (TesterCmdLine cl) =>
                 {
                     // Accepts multi-line snapshots of the VS memory window with
@@ -410,7 +410,7 @@ namespace Tpm2Tester
                     cl.TestCfg.TestsToRun = null;
                     return true;
                 }),
-            new Option("parseOut", "Miscelaneous", "Interpret byte-string as a TPM response",
+            new Option("parseOut", "Miscellaneous", "Interpret byte-string as a TPM response",
                 (TesterCmdLine cl) =>
                 {
                     string commandName = "";
@@ -849,8 +849,8 @@ namespace Tpm2Tester
                 {
                     FilterOutTests(TestsToInclude, Special.NoTRM,
                                    "as the TBS is not in raw mode (device is not 'tbsraw')");
-                    FilterOutTests(TestsToInclude, Category.Context,
-                                   "as the context operations are not available");
+                    FilterOutTests(TestsToInclude, Special.TbsBlocked,
+                                   "as the commands are blocked by TBS (device is not 'tbsraw')");
                 }
             }
 

--- a/Tpm2Tester/TestSubstrate/TestConfig.cs
+++ b/Tpm2Tester/TestSubstrate/TestConfig.cs
@@ -235,5 +235,10 @@ namespace Tpm2Tester
             return DisabledTests.Category.HasFlag(cat);
         }
 
+        public bool IsDisabled(Special special)
+        {
+            return DisabledTests.SpecialNeeds.HasFlag(special);
+        }
+
     } // class TestConfig
 }


### PR DESCRIPTION
This adds a new flag value in the Special enum attribute, TbsBlocked, for marking tests that contain commands that are expected to be blocked by TBS unless running with device tbsraw.

I then changed how tests are filtered out to use the new TbsBlocked flag instead of ones marked as Category.Context. For example, this allows a test for FlushContext, which is not a blocked TBS command, to be run when not in raw mode with appropriate test attributes.

I added a new overload for checking if Special attributes are marked as disabled, so it can be used similarly to how one could previously check if Category.Context was disabled for checking if Special.TbsBlocked is disabled.

Also fixed some typos in comments/help text.