### PR TITLE
Use IsOSPlatform instead of OSDescription.Contains

### DIFF
--- a/Tpm2Tester/TestSubstrate/TestFramework.cs
+++ b/Tpm2Tester/TestSubstrate/TestFramework.cs
@@ -505,7 +505,7 @@ namespace Tpm2Tester
                     case TpmDeviceType.tbs:
                     case TpmDeviceType.tbsraw:
 #if __NETCOREAPP2__
-                        if (!System.Runtime.InteropServices.RuntimeInformation.OSDescription.Contains("Windows", StringComparison.InvariantCultureIgnoreCase))
+                        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                             underlyingTpmDevice = new LinuxTpmDevice();
                         else
 #endif


### PR DESCRIPTION
This fixes #98 by not depending on non-portable overloads of `String.Contains`, and uses a cleaner method to determine OS at runtime.