### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/TSS.JS/package.json
+++ b/TSS.JS/package.json
@@ -11,6 +11,10 @@
     "TPM 2.0",
     "TSS"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/TSS.MSR.git"
+  },
   "optionalDependencies": {
     "ffi-napi": "^2.4.3",
     "net": "^1.0.2",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* tss.js