### PR TITLE
Fixed broken build

### DIFF
--- a/PCPTool.v11/dll/AttestationApi.cpp
+++ b/PCPTool.v11/dll/AttestationApi.cpp
@@ -424,9 +424,9 @@ TpmAttiComputeSoftPCRs(
         goto Cleanup;
     }
 
-    if (FAILED(hr = WbclApiInitIterator(pbEventLog, 
-                                        cbEventLog, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbEventLog, 
+                                          cbEventLog, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -453,9 +453,9 @@ TpmAttiComputeSoftPCRs(
     }
 
     for (; hr == S_OK;
-           hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator, 
                 &PcrIndex, 
                 &EventType,
@@ -632,9 +632,9 @@ TpmAttiFilterLog(
     // Make OACR happy
     *pcbResult = 0;
 
-    if (FAILED(hr = WbclApiInitIterator(pbEventLog, 
-                                        cbEventLog, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbEventLog, 
+                                          cbEventLog, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -650,9 +650,9 @@ TpmAttiFilterLog(
 
     // 1st pass to find out how much space we will need
     for (; hr == S_OK;
-           hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator,
                 &pcrIndex,
                 &eventType,
@@ -694,9 +694,9 @@ TpmAttiFilterLog(
         goto Cleanup;
     }
 
-    if (FAILED(hr = WbclApiInitIterator(pbEventLog, 
-                                        cbEventLog, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbEventLog, 
+                                          cbEventLog, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -723,9 +723,9 @@ TpmAttiFilterLog(
 
     // 2nd pass to copy the entries
     for (; hr == S_OK;
-         hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator,
                 &pcrIndex,
                 &eventType,
@@ -1119,7 +1119,7 @@ TpmAttGeneratePlatformAttestation(
         goto Cleanup;
     }
 
-    if (FAILED(hr = WbclApiInitIterator(pbLog, cbLog, &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbLog, cbLog, &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -2039,18 +2039,18 @@ TpmAttCreateAttestationfromLog(
         goto Cleanup;
     }
 
-    if (FAILED(hr = WbclApiInitIterator(pbLog, 
-                                        cbLog, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbLog, 
+                                          cbLog, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
 
     // parse the log
     for (; hr == S_OK;
-           hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator,
                 &pcrIndex,
                 &eventType,
@@ -2399,9 +2399,9 @@ TpmAttGetPlatformAttestationProperties(
                                    pAttestation->cbSignature];
     cbPlatformLog = pAttestation->cbLog;
 
-    if (FAILED(hr = WbclApiInitIterator(pbPlatformLog, 
-                                        cbPlatformLog, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbPlatformLog, 
+                                          cbPlatformLog, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -2417,9 +2417,9 @@ TpmAttGetPlatformAttestationProperties(
 
     // 2nd pass to copy the entries
     for (; hr == S_OK;
-           hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator,
                 &pcrIndex,
                 &eventType,

--- a/PCPTool.v11/dll/PCPWbcl.cpp
+++ b/PCPTool.v11/dll/PCPWbcl.cpp
@@ -511,7 +511,7 @@ Cleanup:
 //
 
 HRESULT
-WbclApiInitIterator(
+MyWbclApiInitIterator(
     _In_bytecount_(logSize) PVOID  pLogBuffer,
     _In_                    UINT32 logSize,
     _Out_                   WBCL_Iterator* pWbclIterator
@@ -589,12 +589,12 @@ Return value:
     //
     // Extract information for the first event in the log.
     //
-    hr = WbclApiGetCurrentElement(pWbclIterator,
-        &pcrIndex,
-        &eventType,
-        NULL,
-        &firstElementDataSize,
-        NULL);
+    hr = MyWbclApiGetCurrentElement(pWbclIterator,
+                                    &pcrIndex,
+                                    &eventType,
+                                    NULL,
+                                    &firstElementDataSize,
+                                    NULL);
     if (hr != S_OK)
     {
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
@@ -694,9 +694,9 @@ Return value:
 
             //
             // Move to the first log entry after the descriptor.
-            // WbclApiMoveToNextElement() does boundary checks.
+            // MyWbclApiMoveToNextElement() does boundary checks.
             //
-            hr = WbclApiMoveToNextElement(pWbclIterator);
+            hr = MyWbclApiMoveToNextElement(pWbclIterator);
             if (hr != S_OK)
             {
                 hr = HRESULT_FROM_WIN32(ERROR_INVALID_DATA);
@@ -710,7 +710,7 @@ Cleanup:
 }
 
 HRESULT
-WbclApiGetCurrentElement(
+MyWbclApiGetCurrentElement(
     _In_            WBCL_Iterator* pWbclIterator,
     _Out_           UINT32* pcrIndex,
     _Out_           UINT32* eventType,
@@ -787,7 +787,7 @@ Cleanup:
 }
 
 HRESULT
-WbclApiMoveToNextElement(
+MyWbclApiMoveToNextElement(
     _In_ WBCL_Iterator* pWbclIterator)
 /*++
 

--- a/PCPTool.v11/exe/Support.cpp
+++ b/PCPTool.v11/exe/Support.cpp
@@ -850,9 +850,9 @@ PcpToolDisplayLog(
     PcpToolLevelPrefix(level + 1);
     wprintf(L"<WBCL size=\"%u\">\n", cbWBCL);
 
-    if (FAILED(hr = WbclApiInitIterator(pbWBCL, 
-                                        cbWBCL, 
-                                        &wbclIterator)))
+    if (FAILED(hr = MyWbclApiInitIterator(pbWBCL, 
+                                          cbWBCL, 
+                                          &wbclIterator)))
     {
         goto Cleanup;
     }
@@ -862,7 +862,7 @@ PcpToolDisplayLog(
     }
 
     for (; hr == S_OK;
-           hr = WbclApiMoveToNextElement(&wbclIterator))
+           hr = MyWbclApiMoveToNextElement(&wbclIterator))
     {
         BYTE eventDataDigest[MAX_DIGEST_SIZE] = { 0 };
         UINT32 PcrIndex;
@@ -871,7 +871,7 @@ PcpToolDisplayLog(
         PBYTE pbEventData;
         PBYTE pbDigest;
 
-        hr = WbclApiGetCurrentElement(
+        hr = MyWbclApiGetCurrentElement(
                 &wbclIterator, 
                 &PcrIndex, 
                 &EventType,


### PR DESCRIPTION
Issue #94
Problem was because TpmAtt.h was redefining a number of structs from the SDK's wbcl.h, so they have been removed.
TpmAtt.h also declared 3 functions that are already declared in wbcl.h, but we cannot remove them because TpmAtt dll is exporting these functions and thus they must be declared with the __declspec(dllexport) storage class (which wbcl.h doesn't). TpmAtt is defining and exporting these functions because the repo does not have tpmapi.lib to link against. So no choice but to rename them. An alternative solution may be to use a .def file to export the functions (thereby avoiding the need to redeclare the functions with __declspec(dllexport)). This will allow us to keep the original function name.