### PR TITLE
Clean up the TSS.NET csproj

### DIFF
--- a/TSS.NET/TSS.Net/TSS.Net.csproj
+++ b/TSS.NET/TSS.Net/TSS.Net.csproj
@@ -1,52 +1,33 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>TSS.Net</AssemblyName>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <PackageId>TSS.Net</PackageId>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>20210628</Version>
+    <Version>20220422</Version>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
-  <PropertyGroup>
-    <NixTarget>false</NixTarget>
-    <NixTarget Condition="$(RuntimeIdentifier.Contains('linux')) Or '$(OS)' == 'Unix' Or '$(OS)' == 'Linux'">true</NixTarget>
-  </PropertyGroup>
-
+  <Choose>
+    <!-- Don't attempt to target .NET 5 from older Visual Studio / MSBuild versions -->
+    <When Condition="$(VisualStudioVersion) &lt; '16.0'">
+      <PropertyGroup>
+        <TargetFrameworks>net472</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net472;net5</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   <!-- delay sign the assembly for Release build -->
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <AssemblyOriginatorKeyFile>..\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-
   <!-- .NET standard library lacks a CMAC implementation, use BouncyCastle just for this. -->
   <ItemGroup>
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.8" />
   </ItemGroup>
-<!--
-  <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
-  </ItemGroup>
--->
-  <!--
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-	<PropertyGroup Condition="$(TargetFramework).Contains('netcoreapp')) Or $(TargetFramework).Contains('netstandard'))">
-  -->
-  
- <!-- 
-  To build, use:
-    dotnet build TSS.Net.csproj -r linux-x64 -f netcoreapp2.0 -c Release 
-	dotnet build TSS.Net.csproj -r linux-musl-x64 -f netcoreapp2.1 -c Release
-    dotnet build TSS.Net.csproj -r linux-arm -f netcoreapp2.0 -c Release -p:PlatformTarget=ARM 
- -->
- 
 </Project>


### PR DESCRIPTION
This change updates TSS.NET's csproj, performing a few cleanups:

* Remove some old commented-out cruft
* Switch from targeting netcoreapp2.1 (which is no longer supported) to net5
* Target net5 only from supported versions of Visual Studio

This allows e.g., Visual Studio 2017 to only attempt to target .NET
Framework 4.7.2, while building with the msbuild from .NET 5.0 or .NET
6.0 (via `dotnet`) targets both Framework 4.7.2 and .NET 5.0.

Tested by building:

* From VS2017 on Windows 10
* From dotnet (.NET 5) on Linux
* From dotnet (.NET 6) on Linux