### PR TITLE
Do not suppress exceptions

### DIFF
--- a/TSS.NET/TSS.Net.UWP/BCryptInterface.cs
+++ b/TSS.NET/TSS.Net.UWP/BCryptInterface.cs
@@ -153,8 +153,7 @@ namespace Tpm2Lib
                     return Globs.CopyData(keyBlob, 12);
                 }
             }
-            Globs.Throw("ExportSymKey(): " + (keyBlob != null ? "Invalid" : "No") + " symmetric key blob returned");
-            return null;
+            throw new Exception("ExportSymKey(): " + (keyBlob != null ? "Invalid" : "No") + " symmetric key blob returned");
         }
 
         public byte[] Encrypt(byte[] input, BCryptOaepPaddingInfo paddingInfo = null,
@@ -183,8 +182,7 @@ namespace Tpm2Lib
                     Debug.Assert(blockLen > 0);
                     if (blockLen != iv.Length)
                     {
-                        Globs.Throw<ArgumentException>("Encrypt(): Invalid IV size " + iv.Length);
-                        return null;
+                        throw new ArgumentException("Encrypt(): Invalid IV size " + iv.Length);
                     }
                     // BCRYPT_BLOCK_PADDING causes gratuitous padding for block-aligned data buffers
                     //flags |= BCRYPT_BLOCK_PADDING;
@@ -232,9 +230,8 @@ namespace Tpm2Lib
                     Debug.Assert(blockLen > 0);
                     if (blockLen != iv.Length)
                     {
-                        Globs.Throw<ArgumentException>("Encrypt(): Invalid IV size ("
+                        throw new ArgumentException("Encrypt(): Invalid IV size ("
                                         + iv.Length + " instead of " + blockLen + ")");
-                        return null;
                     }
                     // BCRYPT_BLOCK_PADDING causes gratuitous padding for block-aligned data buffers
                     //flags |= Native.BCRYPT_BLOCK_PADDING;
@@ -402,8 +399,7 @@ namespace Tpm2Lib
         {
             if (Handle != UIntPtr.Zero)
             {
-                Globs.Throw("BCryptInterface.Open(): Already opened.");
-                return;
+                throw new Exception("BCryptInterface.Open(): Already opened.");
             }
             LastError = Native.BCryptOpenAlgorithmProvider(out Handle, algName,
                                                            Native.MS_PRIMITIVE_PROVIDER, flags);
@@ -513,8 +509,7 @@ namespace Tpm2Lib
             {
                 if (prime2 == null || prime2.Length == 0)
                 {
-                    Globs.Throw<ArgumentException>("LoadRSAKey(): The second prime is missing");
-                    return UIntPtr.Zero;
+                    throw new ArgumentException("LoadRSAKey(): The second prime is missing");
                 }
                 primeLen1 = (uint)prime1.Length;
                 primeLen2 = (uint)prime2.Length;
@@ -522,8 +517,7 @@ namespace Tpm2Lib
             }
             else if (prime2 != null && prime2.Length > 0)
             {
-                Globs.Throw<ArgumentException>("LoadRSAKey(): The first prime is missing");
-                return UIntPtr.Zero;
+                throw new ArgumentException("LoadRSAKey(): The first prime is missing");
             }
 
             var rsaKey = new byte[rsaKeySize];
@@ -561,8 +555,7 @@ namespace Tpm2Lib
             string modeName = Native.BCryptChainingMode(symDef.Mode);
             if (string.IsNullOrEmpty(modeName))
             {
-                Globs.Throw<ArgumentException>("LoadSymKey(): Unsupported chaining mode " + symDef.Mode);
-                return UIntPtr.Zero;
+                throw new ArgumentException("LoadSymKey(): Unsupported chaining mode " + symDef.Mode);
             }
 
             // Create key blob for import
@@ -600,8 +593,7 @@ namespace Tpm2Lib
             string modeName = Native.BCryptChainingMode(symDef.Mode);
             if (string.IsNullOrEmpty(modeName))
             {
-                Globs.Throw<ArgumentException>("GenerateSymKey(): Unsupported chaining mode " + symDef.Mode);
-                return null;
+                throw new ArgumentException("GenerateSymKey(): Unsupported chaining mode " + symDef.Mode);
             }
             UIntPtr keyHandle = UIntPtr.Zero;
             int keySize = symDef.KeyBits / 8;
@@ -615,8 +607,7 @@ namespace Tpm2Lib
             }
             if (keyData != null && keyData.Length != keySize)
             {
-                Globs.Throw<ArgumentException>("GenerateSymKey(): Invalid key length");
-                return UIntPtr.Zero;
+                throw new ArgumentException("GenerateSymKey(): Invalid key length");
             }
             LastError = Native.BCryptGenerateSymmetricKey(Handle, out keyHandle, UIntPtr.Zero, 0,
                                                           keyData ?? Globs.GetRandomBytes(keySize),
@@ -1006,14 +997,14 @@ namespace Tpm2Lib
                         case EccCurve.NistP521:
                             return signing ? BCRYPT_ECDSA_P521_ALGORITHM : BCRYPT_ECDH_P521_ALGORITHM;
                     }
-                    Globs.Throw<ArgumentException>("Unsupported ECC curve");
+                    throw new ArgumentException("Unsupported ECC curve");
                     return null;
                 case TpmAlgId.Aes:
                     return BCRYPT_AES_ALGORITHM;
                 case TpmAlgId.Sha512:
                     return BCRYPT_SHA512_ALGORITHM;
             }
-            Globs.Throw<ArgumentException>("Unsupported algorithm");
+            throw new ArgumentException("Unsupported algorithm");
             return null;
         }
 #endif
@@ -1370,9 +1361,7 @@ namespace Tpm2Lib
             var keyAlg = cspPrivate.publicKeyStruc.aiKeyAlg;
             if (keyAlg != Csp.AlgId.CAlgRsaKeyX && keyAlg != Csp.AlgId.CAlgRsaSign)
             {
-                Globs.Throw<NotSupportedException>("CSP blobs for keys of type " + keyAlg.ToString("X") + " are not supported");
-                tpmPub = new TpmPublic();
-                return new TpmPrivate();
+                throw new NotSupportedException("CSP blobs for keys of type " + keyAlg.ToString("X") + " are not supported");
             }
 
             var rsaPriv = new Tpm2bPrivateKeyRsa(Globs.ReverseByteOrder(cspPrivate.prime1));

--- a/TSS.NET/TSS.Net.UWP/CryptoAsym.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoAsym.cs
@@ -53,8 +53,7 @@ namespace Tpm2Lib
                     Key = Generate(Native.BCRYPT_RSA_ALGORITHM, rsaParams.keyBits);
                     if (Key == UIntPtr.Zero)
                     {
-                        Globs.Throw("Failed to generate RSA key");
-                        return;
+                        throw new Exception("Failed to generate RSA key");
                     }
                     byte[] blob = Export(Native.BCRYPT_RSAPUBLIC_BLOB);
                     var m = new Marshaller(blob, DataRepresentation.LittleEndian);
@@ -72,8 +71,7 @@ namespace Tpm2Lib
                     var alg = RawEccKey.GetEccAlg(keyParams);
                     if (alg == null)
                     {
-                        Globs.Throw<ArgumentException>("Unknown ECC curve");
-                        return;
+                       throw new ArgumentException("Unknown ECC curve");
                     }
 
                     byte[] keyIs;
@@ -107,8 +105,7 @@ namespace Tpm2Lib
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("Algorithm not supported");
-                    break;
+                    throw new ArgumentException("Algorithm not supported");
             }
         }
 
@@ -172,15 +169,12 @@ namespace Tpm2Lib
                     alg.Close();
                     if (cs.Key == UIntPtr.Zero)
                     {
-                        Globs.Throw("Failed to create new RSA key");
-                        return null;
+                        throw new Exception("Failed to create new RSA key");
                     }
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("Algorithm not supported");
-                    cs = null;
-                    break;
+                    throw new ArgumentException("Algorithm not supported");
             }
             return cs;
         }
@@ -218,7 +212,7 @@ namespace Tpm2Lib
             ushort privSize = m.Get<UInt16>();
             if (fromCspPrivate.buffer.Length != privSize + 2)
             {
-                Globs.Throw("Invalid key blob");
+                throw new Exception("Invalid key blob");
             }
             return m.Get<Sensitive>();
         }
@@ -261,12 +255,10 @@ namespace Tpm2Lib
                     }
                     case TpmAlgId.Rsapss:
                     {
-                        Globs.Throw<ArgumentException>("SignData(): PSS scheme is not supported");
-                        return null;
+                        throw new ArgumentException("SignData(): PSS scheme is not supported");
                     }
                 }
-                Globs.Throw<ArgumentException>("Unsupported signature scheme");
-                return null;
+                throw new ArgumentException("Unsupported signature scheme");
             }
 
             var eccParms = PublicParms.parameters as EccParms;
@@ -274,8 +266,7 @@ namespace Tpm2Lib
             {
                 if (eccParms.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
-                    return null;
+                    throw new ArgumentException("Unsupported ECC sig scheme");
                 }
                 if (sigHash == TpmAlgId.Null)
                 {
@@ -289,8 +280,7 @@ namespace Tpm2Lib
             }
 
             // Should never be here
-            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
-            return null;
+            throw new Exception("VerifySignature: Unrecognized asymmetric algorithm");
         } // SignData()
 
         /// <summary>
@@ -346,8 +336,7 @@ namespace Tpm2Lib
 
                 if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
                 {
-                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
-                    return false;
+                    throw new ArgumentException("Key scheme and signature scheme do not match");
                 }
 
                 byte[] digest = dataIsDigest ? data : CryptoLib.HashData(sigHash, data);
@@ -358,11 +347,9 @@ namespace Tpm2Lib
                 }
                 if (sigScheme == TpmAlgId.Rsapss)
                 {
-                    Globs.Throw<ArgumentException>("VerifySignature(): PSS scheme is not supported");
-                    return false;
+                    throw new ArgumentException("VerifySignature(): PSS scheme is not supported");
                 }
-                Globs.Throw<ArgumentException>("VerifySignature(): Unrecognized scheme");
-                return false;
+                throw new ArgumentException("VerifySignature(): Unrecognized scheme");
             }
 
             var eccParams = PublicParms.parameters as EccParms;
@@ -370,15 +357,13 @@ namespace Tpm2Lib
             {
                 if (eccParams.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
-                    return false;
+                    throw new ArgumentException("Unsupported ECC sig scheme");
                 }
                 TpmAlgId keyScheme = eccParams.scheme.GetUnionSelector();
 
                 if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
                 {
-                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
-                    return false;
+                    throw new ArgumentException("Key scheme and signature scheme do not match");
                 }
 
                 var s = sig as SignatureEcdsa;
@@ -388,8 +373,7 @@ namespace Tpm2Lib
             }
 
             // Should never be here
-            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
-            return false;
+            throw new Exception("VerifySignature: Unrecognized asymmetric algorithm");
         } // VerifySignature()
 
         /// <summary>
@@ -713,8 +697,7 @@ namespace Tpm2Lib
             int pad = sizeWanted - len;
             if (pad < 0)
             {
-                Globs.Throw<ArgumentException>("ToBigEndian(): Too short size requested");
-                return new byte[0];
+                throw new ArgumentException("ToBigEndian(): Too short size requested");
             }
 
             var b2 = new byte[sizeWanted];
@@ -818,8 +801,7 @@ namespace Tpm2Lib
         {
             if (s.Length != KeySize)
             {
-                Globs.Throw<ArgumentException>("PkcsVerify: Invalid signature");
-                return false;
+                throw new ArgumentException("PkcsVerify: Invalid signature");
             }
             int k = KeySize;
             BigInteger sig = FromBigEndian(s);
@@ -886,8 +868,7 @@ namespace Tpm2Lib
                 case EccCurve.NistP521:
                     return 521;
             }
-            Globs.Throw<ArgumentException>("GetKeyLength(): Invalid ECC curve");
-            return -1;
+            throw new ArgumentException("GetKeyLength(): Invalid ECC curve");
         }
 
         internal static uint MagicFromTpmAlgId(TpmAlgId algId, bool isEcdh, EccCurve curve, bool publicKey)
@@ -897,7 +878,7 @@ namespace Tpm2Lib
                                                     x.Ecdh == isEcdh)).Magic;
             if (res == 0)
             {
-                Globs.Throw("Unrecognized ECC parameter set");
+                throw new Exception("Unrecognized ECC parameter set");
             }
             return res;
         }
@@ -912,8 +893,7 @@ namespace Tpm2Lib
 
             if (x.Length != keySizeBytes || y.Length != keySizeBytes)
             {
-                Globs.Throw<ArgumentException>("GetKeyBlob: Malformed ECC key");
-                return new byte[0];
+                throw new ArgumentException("GetKeyBlob: Malformed ECC key");
             }
 
             var size = Globs.ReverseByteOrder(Globs.HostToNet(keySizeBytes));
@@ -934,7 +914,7 @@ namespace Tpm2Lib
 
             if (!magicOk)
             {
-                Globs.Throw<ArgumentException>("KeyInfoFromPublicBlob: Public key blob magic not recognized");
+                throw new ArgumentException("KeyInfoFromPublicBlob: Public key blob magic not recognized");
             }
 
             uint cbKey = BitConverter.ToUInt32(m.GetNBytes(4), 0);
@@ -980,20 +960,17 @@ namespace Tpm2Lib
             bool encrypting = pub.objectAttributes.HasFlag(ObjectAttr.Decrypt);
             if (!(signing ^ encrypting))
             {
-                Globs.Throw<ArgumentException>("ECC Key must either sign or decrypt");
-                return null;
+                throw new ArgumentException("ECC Key must either sign or decrypt");
             }
             var scheme = eccParms.scheme.GetUnionSelector();
             if (signing && scheme != TpmAlgId.Ecdsa && scheme != TpmAlgId.Null)
             {
-                Globs.Throw<ArgumentException>("Unsupported ECC signing scheme");
-                return null;
+                throw new ArgumentException("Unsupported ECC signing scheme");
             }
 
             if (!IsCurveSupported(eccParms.curveID))
             {
-                Globs.Throw<ArgumentException>("Unsupported ECC curve");
-                return null;
+                throw new ArgumentException("Unsupported ECC curve");
             }
             int curveIndex = (int)eccParms.curveID;
             return signing ? EcdsaCurveIDs[curveIndex] : EcdhCurveIDs[curveIndex];

--- a/TSS.NET/TSS.Net.UWP/CryptoLib.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoLib.cs
@@ -20,8 +20,7 @@ namespace Tpm2Lib
             string algName = Native.BCryptHashAlgName(algId);
             if (string.IsNullOrEmpty(algName))
             {
-                Globs.Throw<ArgumentException>("HashData(): Unsupported hash algorithm " + algId);
-                return null;
+                throw new ArgumentException("HashData(): Unsupported hash algorithm " + algId);
             }
 
             var alg = new BCryptAlgorithm(algName);
@@ -85,8 +84,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Null:
                     return 0;
             }
-            Globs.Throw<ArgumentException>("DigestSize(): Unsupported hash algorithm");
-            return 0;
+            throw new ArgumentException("DigestSize(): Unsupported hash algorithm");
         }
 
         public static int BlockSize(TpmAlgId algId)
@@ -108,8 +106,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Null:
                     return 0;
             }
-            Globs.Throw<ArgumentException>("BlockSize{}: Unsupported hash or MAC  algorithm");
-            return 0;
+            throw new ArgumentException("BlockSize{}: Unsupported hash or MAC  algorithm");
         }
 
         public static TpmAlgId SchemeHash (ISignatureUnion sig)
@@ -128,8 +125,7 @@ namespace Tpm2Lib
             string algName = Native.BCryptHashAlgName(hashAlgId);
             if (string.IsNullOrEmpty(algName))
             {
-                Globs.Throw<ArgumentException>("CryptoLib.Hmac(): Unsupported hash algorithm " + hashAlgId);
-                return null;
+                throw new ArgumentException("CryptoLib.Hmac(): Unsupported hash algorithm " + hashAlgId);
             }
 
             var alg = new BCryptAlgorithm(algName, Native.BCRYPT_ALG_HANDLE_HMAC);
@@ -142,13 +138,11 @@ namespace Tpm2Lib
         {
             if (symAlg != TpmAlgId.Aes)
             {
-                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported symmetric algorithm" + symAlg);
-                return null;
+                throw new ArgumentException("CryptoLib.Mac(): Unsupported symmetric algorithm" + symAlg);
             }
             if (macScheme != TpmAlgId.Cmac)
             {
-                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported MAC scheme " + macScheme);
-                return null;
+                throw new ArgumentException("CryptoLib.Mac(): Unsupported MAC scheme " + macScheme);
             }
 
             var alg = new BCryptAlgorithm(Native.BCRYPT_AES_CMAC_ALGORITHM);
@@ -224,8 +218,7 @@ namespace Tpm2Lib
             // 2
             if (messageLength > encodedMessageLength - 2 * hashLength - 1)
             {
-                Globs.Throw<ArgumentException>("OaepEncode: Input message too long");
-                return new byte[0];
+                throw new ArgumentException("OaepEncode: Input message too long");
             }
             int psLen = encodedMessageLength - messageLength - 2 * hashLength - 1;
             var ps = new byte[psLen];
@@ -356,8 +349,7 @@ namespace Tpm2Lib
             // 3
             if (emLen < hLen + sLen + 2)
             {
-                Globs.Throw("PssEncode: Encoding error");
-                return new byte[0];
+                throw new Exception("PssEncode: Encoding error");
             }
 
             // 4
@@ -528,8 +520,7 @@ namespace Tpm2Lib
                     };
                     break;
                 default:
-                    Globs.Throw<ArgumentException>("Pkcs15Encode: Unsupported hashAlg");
-                    return new byte[0];
+                    throw new ArgumentException("Pkcs15Encode: Unsupported hashAlg");
             }
             byte[] messageHash = TpmHash.FromData(hashAlg, m);
             byte[] T = Globs.Concatenate(prefix, messageHash);
@@ -537,8 +528,7 @@ namespace Tpm2Lib
 
             if (emLen < tLen + 11)
             {
-                Globs.Throw<ArgumentException>("Pkcs15Encode: Encoded message is too short");
-                return new byte[0];
+                throw new ArgumentException("Pkcs15Encode: Encoded message is too short");
             }
 
             byte[] ps = Globs.ByteArray(emLen - tLen - 3, 0xff);
@@ -554,8 +544,7 @@ namespace Tpm2Lib
         {
             if (p1.Length != p2.Length)
             {
-                Globs.Throw<ArgumentException>("XorEngine: Mismatched arguments length");
-                return new byte[0];
+                throw new ArgumentException("XorEngine: Mismatched arguments length");
             }
             var res = new byte[p1.Length];
             for (int j = 0; j < p1.Length; j++)
@@ -627,9 +616,7 @@ namespace Tpm2Lib
         {
             if (numBits1 % 8 != 0 || numBits2 % 8 != 0)
             {
-                Globs.Throw<NotImplementedException>("Split: Only byte-sized chunks are supported");
-                a1 = a2 = new byte[0];
-                return;
+                throw new NotImplementedException("Split: Only byte-sized chunks are supported");
             }
             a1 = new byte[(numBits1 + 7) / 8];
             Array.Copy(inData, 0, a1, 0, (numBits1 + 7) / 8);

--- a/TSS.NET/TSS.Net.UWP/CryptoSymm.cs
+++ b/TSS.NET/TSS.Net.UWP/CryptoSymm.cs
@@ -51,8 +51,7 @@ namespace Tpm2Lib
             }
             if (symDef.Algorithm != TpmAlgId.Aes)
             {
-                Globs.Throw<ArgumentException>("Unsupported algorithm " + symDef.Algorithm);
-                return 0;
+                throw new ArgumentException("Unsupported algorithm " + symDef.Algorithm);
             }
             return 16;
         }
@@ -83,9 +82,8 @@ namespace Tpm2Lib
                     alg = new BCryptAlgorithm(Native.BCRYPT_3DES_ALGORITHM);
                     break;
                 default:
-                    Globs.Throw<ArgumentException>("Unsupported symmetric algorithm "
+                    throw new ArgumentException("Unsupported symmetric algorithm "
                                                    + symDef.Algorithm);
-                    return null;
             }
 
             if (keyData == null)
@@ -108,8 +106,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Ecc:
                     return Create((parms as EccParms).symmetric);
                 default:
-                    Globs.Throw<ArgumentException>("CreateFromPublicParms: Unsupported algorithm");
-                    return null;
+                    throw new ArgumentException("CreateFromPublicParms: Unsupported algorithm");
             }
         }
 
@@ -196,7 +193,7 @@ namespace Tpm2Lib
 
                 if (!Globs.ArraysAreEqual(expectedInnerIntegrity, innerIntegrity))
                 {
-                    Globs.Throw("SensitiveFromDupBlob: Bad inner integrity");
+                    throw new Exception("SensitiveFromDupBlob: Bad inner integrity");
                 }
 
                 sensNoLen = Marshaller.Tpm2BToBuffer(sensitive);

--- a/TSS.NET/TSS.Net.UWP/SupportClasses.cs
+++ b/TSS.NET/TSS.Net.UWP/SupportClasses.cs
@@ -80,10 +80,7 @@ namespace Tpm2Lib
         {
             if (pos + bytesToSet.Length > GetSize())
             {
-                Globs.Throw<ArgumentOutOfRangeException>("Position is not in allocated buffer");
-                if (GetSize() > pos)
-                    Array.Copy(bytesToSet, 0, Buf, pos, GetSize() - pos);
-                return;
+                throw new ArgumentOutOfRangeException("Position is not in allocated buffer");
             }
             Array.Copy(bytesToSet, 0, Buf, pos, bytesToSet.Length);
         }
@@ -127,9 +124,7 @@ namespace Tpm2Lib
         {
             if (newGetPos < 0 || newGetPos > GetSize())
             {
-                Globs.Throw("SetGetPos: Invalid position");
-                GetPos = newGetPos < 0 ? 0 : GetSize();
-                return;
+                throw new Exception("SetGetPos: Invalid position");
             }
             GetPos = newGetPos;
         }
@@ -138,9 +133,8 @@ namespace Tpm2Lib
         {
             if (GetPos + num > PutPos)
             {
-                Globs.Throw<ArgumentOutOfRangeException>("ByteBuf exception removing "
+                throw new ArgumentOutOfRangeException("ByteBuf exception removing "
                     + num + " bytes at position " + GetPos + " from an array of " + PutPos);
-                return null;
             }
             var ret = new byte[num];
             Array.Copy(Buf, GetPos, ret, 0, num);
@@ -231,8 +225,7 @@ namespace Tpm2Lib
         {
             if (numBytes > RandMaxBytes)
             {
-                Globs.Throw<ArgumentException>("GetRandomBytes: Too many bytes requested " + numBytes);
-                numBytes = RandMaxBytes;
+                throw new ArgumentException("GetRandomBytes: Too many bytes requested " + numBytes);
             }
             // Make sure that the RNG is properly seeded
             if (Seed == null)
@@ -480,7 +473,7 @@ namespace Tpm2Lib
                     return;
                 }
             }
-            Globs.Throw<NotImplementedException>("Print: Unknown type " + o.GetType());
+            throw new NotImplementedException("Print: Unknown type " + o.GetType());
         }
 
         private string Spaces()

--- a/TSS.NET/TSS.Net/CryptoAsym.cs
+++ b/TSS.NET/TSS.Net/CryptoAsym.cs
@@ -71,8 +71,7 @@ namespace Tpm2Lib
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("Algorithm not supported");
-                    break;
+                    throw new ArgumentException("Algorithm not supported");
             }
         }
 
@@ -147,9 +146,7 @@ namespace Tpm2Lib
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("Algorithm not supported");
-                    cs = null;
-                    break;
+                    throw new ArgumentException("Algorithm not supported");
             }
             return cs;
         }
@@ -194,13 +191,11 @@ namespace Tpm2Lib
             }
             else if (EcdsaProvider != null || EcDhProvider != null)
             {
-                Globs.Throw<NotSupportedException>("Blobs for ECC keys are not supported.");
-                tpmPub = new TpmPublic();
+                throw new NotSupportedException("Blobs for ECC keys are not supported.");
             }
             else
             {
-                Globs.Throw<NotSupportedException>("Blobs for non-RSA, non-ECC keys are not supported.");
-                tpmPub = new TpmPublic();
+                throw new NotSupportedException("Blobs for non-RSA, non-ECC keys are not supported.");
             }
 
             return new TpmPrivate(sens.GetTpm2BRepresentation());
@@ -214,7 +209,7 @@ namespace Tpm2Lib
             ushort privSize = m.Get<UInt16>();
             if (priv.buffer.Length != privSize + 2)
             {
-                Globs.Throw("Invalid key blob");
+                throw new Exception("Invalid key blob");
             }
             return m.Get<Sensitive>();
         }
@@ -264,8 +259,7 @@ namespace Tpm2Lib
                         return new SignatureRsapss(sigHash, sig);
                     }
                 }
-                Globs.Throw<ArgumentException>("Unsupported signature scheme");
-                return null;
+                throw new ArgumentException("Unsupported signature scheme");
             }
 
             var eccParms = PublicParms.parameters as EccParms;
@@ -273,8 +267,7 @@ namespace Tpm2Lib
             {
                 if (eccParms.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
-                    return null;
+                    throw new ArgumentException("Unsupported ECC sig scheme");
                 }
                 if (sigHash == TpmAlgId.Null)
                 {
@@ -291,8 +284,7 @@ namespace Tpm2Lib
             }
 
             // Should never be here
-            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
-            return null;
+            throw new Exception("VerifySignature: Unrecognized asymmetric algorithm");
         } // SignData()
 
         /// <summary>
@@ -348,7 +340,7 @@ namespace Tpm2Lib
 
                 if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
                 {
-                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
+                    throw new ArgumentException("Key scheme and signature scheme do not match");
                 }
 
                 var paddingScheme = RSASignaturePadding.Pkcs1;
@@ -366,8 +358,7 @@ namespace Tpm2Lib
                     }
                     default:
                     {
-                        Globs.Throw<ArgumentException>("VerifySignature(): Unrecognized scheme");
-                        break;
+                        throw new ArgumentException("VerifySignature(): Unrecognized scheme");
                     }
                 }
 
@@ -384,13 +375,13 @@ namespace Tpm2Lib
             {
                 if (eccParams.scheme.GetUnionSelector() != TpmAlgId.Ecdsa)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported ECC sig scheme");
+                    throw new ArgumentException("Unsupported ECC sig scheme");
                 }
                 TpmAlgId keyScheme = eccParams.scheme.GetUnionSelector();
 
                 if (keyScheme != TpmAlgId.Null && keyScheme != sigScheme)
                 {
-                    Globs.Throw<ArgumentException>("Key scheme and signature scheme do not match");
+                    throw new ArgumentException("Key scheme and signature scheme do not match");
                 }
 
                 var s = sig as SignatureEcdsa;
@@ -404,8 +395,7 @@ namespace Tpm2Lib
             }
 
             // Should never be here
-            Globs.Throw("VerifySignature: Unrecognized asymmetric algorithm");
-            return false;
+            throw new Exception("VerifySignature: Unrecognized asymmetric algorithm");
         } // VerifySignature()
 
         /// <summary>
@@ -746,8 +736,7 @@ namespace Tpm2Lib
             int pad = sizeWanted - len;
             if (pad < 0)
             {
-                Globs.Throw<ArgumentException>("ToBigEndian(): Too short size requested");
-                return new byte[0];
+                throw new ArgumentException("ToBigEndian(): Too short size requested");
             }
 
             var b2 = new byte[sizeWanted];
@@ -851,8 +840,7 @@ namespace Tpm2Lib
         {
             if (s.Length != KeySize)
             {
-                Globs.Throw<ArgumentException>("PkcsVerify: Invalid signature");
-                return false;
+                throw new ArgumentException("PkcsVerify: Invalid signature");
             }
             int k = KeySize;
             BigInteger sig = FromBigEndian(s);
@@ -896,8 +884,7 @@ namespace Tpm2Lib
         {
             if (!IsCurveSupported(curveID))
             {
-                Globs.Throw<ArgumentException>("Unsupported ECC curve");
-                return ECCurve.CreateFromFriendlyName("nistP256");
+                throw new ArgumentException("Unsupported ECC curve");
             }
             ECCurve curve;
             EccCurves.TryGetValue(curveID, out curve);
@@ -908,7 +895,7 @@ namespace Tpm2Lib
         {
             if (pub.unique.GetUnionSelector() != TpmAlgId.Ecc)
             {
-                Globs.Throw<ArgumentException>("Not an ECC key");
+                throw new ArgumentException("Not an ECC key");
             }
 
             var eccParms = (EccParms)pub.parameters;
@@ -917,12 +904,12 @@ namespace Tpm2Lib
             bool encrypting = pub.objectAttributes.HasFlag(ObjectAttr.Decrypt);
             if (!(signing ^ encrypting))
             {
-                Globs.Throw<ArgumentException>("ECC Key must either sign or decrypt");
+                throw new ArgumentException("ECC Key must either sign or decrypt");
             }
             var scheme = eccParms.scheme.GetUnionSelector();
             if (signing && scheme != TpmAlgId.Ecdsa && scheme != TpmAlgId.Null)
             {
-                Globs.Throw<ArgumentException>("Unsupported ECC signing scheme");
+                throw new ArgumentException("Unsupported ECC signing scheme");
             }
 
             return GetEccCurve(eccParms.curveID);

--- a/TSS.NET/TSS.Net/CryptoLib.cs
+++ b/TSS.NET/TSS.Net/CryptoLib.cs
@@ -37,8 +37,7 @@ namespace Tpm2Lib
                     hashAlg = new SHA512Managed();
                     break;
                 default:
-                    Globs.Throw<ArgumentException>("AlgId is not a supported hash algorithm");
-                    return null;
+                    throw new ArgumentException("AlgId is not a supported hash algorithm");
             }
             return hashAlg.ComputeHash(dataToHash);
         }
@@ -98,8 +97,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Null:
                     return 0;
             }
-            Globs.Throw<ArgumentException>("DigestSize(): Unsupported hash algorithm");
-            return 0;
+            throw new ArgumentException("DigestSize(): Unsupported hash algorithm");
         }
 
         public static int BlockSize(TpmAlgId algId)
@@ -121,8 +119,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Null:
                     return 0;
             }
-            Globs.Throw<ArgumentException>("BlockSize{}: Unsupported hash or MAC  algorithm");
-            return 0;
+            throw new ArgumentException("BlockSize{}: Unsupported hash or MAC  algorithm");
         }
 
         public static TpmAlgId SchemeHash (ISignatureUnion sig)
@@ -154,8 +151,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Sha512:
                     return HashAlgorithmName.SHA512;
             }
-            Globs.Throw<ArgumentException>("Unsupported hash algorithm");
-            return HashAlgorithmName.SHA1;
+            throw new ArgumentException("Unsupported hash algorithm");
         }
 
         public static byte[] Hmac(TpmAlgId hashAlgId, byte[] key, byte[] data)
@@ -183,8 +179,7 @@ namespace Tpm2Lib
                         return h4.ComputeHash(data);
                     }
                 default:
-                    Globs.Throw<ArgumentException>("Hmac(): Unsupported hash algorithm " + hashAlgId);
-                    return null;
+                    throw new ArgumentException("Hmac(): Unsupported hash algorithm " + hashAlgId);
             }
         }
 
@@ -192,13 +187,11 @@ namespace Tpm2Lib
         {
             if (symAlg != TpmAlgId.Aes)
             {
-                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported symmetric algorithm" + symAlg);
-                return null;
+                throw new ArgumentException("CryptoLib.Mac(): Unsupported symmetric algorithm" + symAlg);
             }
             if (macScheme != TpmAlgId.Cmac)
             {
-                Globs.Throw<ArgumentException>("CryptoLib.Mac(): Unsupported MAC scheme " + macScheme);
-                return null;
+                throw new ArgumentException("CryptoLib.Mac(): Unsupported MAC scheme " + macScheme);
             }
 
             var mac = new BouncyCastleCMAC(new BouncyCastleAES());
@@ -276,8 +269,7 @@ namespace Tpm2Lib
             // 2
             if (messageLength > encodedMessageLength - 2 * hashLength - 1)
             {
-                Globs.Throw<ArgumentException>("OaepEncode: Input message too long");
-                return new byte[0];
+                throw new ArgumentException("OaepEncode: Input message too long");
             }
             int psLen = encodedMessageLength - messageLength - 2 * hashLength - 1;
             var ps = new byte[psLen];
@@ -408,8 +400,7 @@ namespace Tpm2Lib
             // 3
             if (emLen < hLen + sLen + 2)
             {
-                Globs.Throw("PssEncode: Encoding error");
-                return new byte[0];
+                throw new Exception("PssEncode: Encoding error");
             }
 
             // 4
@@ -580,8 +571,7 @@ namespace Tpm2Lib
                     };
                     break;
                 default:
-                    Globs.Throw<ArgumentException>("Pkcs15Encode: Unsupported hashAlg");
-                    return new byte[0];
+                    throw new ArgumentException("Pkcs15Encode: Unsupported hashAlg");
             }
             byte[] messageHash = TpmHash.FromData(hashAlg, m);
             byte[] T = Globs.Concatenate(prefix, messageHash);
@@ -589,8 +579,7 @@ namespace Tpm2Lib
 
             if (emLen < tLen + 11)
             {
-                Globs.Throw<ArgumentException>("Pkcs15Encode: Encoded message is too short");
-                return new byte[0];
+                throw new ArgumentException("Pkcs15Encode: Encoded message is too short");
             }
 
             byte[] ps = Globs.ByteArray(emLen - tLen - 3, 0xff);
@@ -606,8 +595,7 @@ namespace Tpm2Lib
         {
             if (p1.Length != p2.Length)
             {
-                Globs.Throw<ArgumentException>("XorEngine: Mismatched arguments length");
-                return new byte[0];
+                throw new ArgumentException("XorEngine: Mismatched arguments length");
             }
             var res = new byte[p1.Length];
             for (int j = 0; j < p1.Length; j++)
@@ -679,9 +667,7 @@ namespace Tpm2Lib
         {
             if (numBits1 % 8 != 0 || numBits2 % 8 != 0)
             {
-                Globs.Throw<NotImplementedException>("Split: Only byte-sized chunks are supported");
-                a1 = a2 = new byte[0];
-                return;
+                throw new NotImplementedException("Split: Only byte-sized chunks are supported");
             }
             a1 = new byte[(numBits1 + 7) / 8];
             Array.Copy(inData, 0, a1, 0, (numBits1 + 7) / 8);

--- a/TSS.NET/TSS.Net/CryptoSymm.cs
+++ b/TSS.NET/TSS.Net/CryptoSymm.cs
@@ -60,8 +60,7 @@ namespace Tpm2Lib
             }
             if (symDef.Algorithm != TpmAlgId.Aes)
             {
-                Globs.Throw<ArgumentException>("Unsupported algorithm " + symDef.Algorithm);
-                return 0;
+                throw new ArgumentException("Unsupported algorithm " + symDef.Algorithm);
             }
             return 16;
         }
@@ -106,7 +105,7 @@ namespace Tpm2Lib
                     limitedSupport = true;
                     break;
                 default:
-                    //Globs.Throw<ArgumentException>("Unsupported symmetric algorithm " + symDef.Algorithm);
+                    //throw new ArgumentException("Unsupported symmetric algorithm " + symDef.Algorithm);
                     return null;
             }
 
@@ -168,8 +167,7 @@ namespace Tpm2Lib
                     // CTR in .NET requires you to manage your own counter.
                     return CipherMode_None;
                 default:
-                    Globs.Throw<ArgumentException>("GetCipherMode: Unsupported cipher mode");
-                    return CipherMode_None;
+                    throw new ArgumentException("GetCipherMode: Unsupported cipher mode");
             }
         }
 
@@ -182,8 +180,7 @@ namespace Tpm2Lib
                 case TpmAlgId.Ecc:
                     return Create((parms as EccParms).symmetric);
                 default:
-                    Globs.Throw<ArgumentException>("CreateFromPublicParms: Unsupported algorithm");
-                    return null;
+                    throw new ArgumentException("CreateFromPublicParms: Unsupported algorithm");
             }
         }
 
@@ -274,8 +271,7 @@ namespace Tpm2Lib
                 case CipherMode.ECB:
                     break;
                 case CipherMode.CTS:
-                    Globs.Throw<ArgumentException>("Encrypt: Unsupported symmetric mode");
-                    break;
+                    throw new ArgumentException("Encrypt: Unsupported symmetric mode");
                 }
             }
             return unpadded == 0 ? paddedData : Globs.CopyData(paddedData, 0, data.Length);
@@ -352,8 +348,7 @@ namespace Tpm2Lib
                 case CipherMode.ECB:
                     break;
                 case CipherMode.CTS:
-                    Globs.Throw<ArgumentException>("Decrypt: Unsupported symmetric mode");
-                    break;
+                    throw new ArgumentException("Decrypt: Unsupported symmetric mode");
                 }
             }
             return tempOut;
@@ -399,7 +394,7 @@ namespace Tpm2Lib
 
                 if (!Globs.ArraysAreEqual(expectedInnerIntegrity, innerIntegrity))
                 {
-                    Globs.Throw("SensitiveFromDupBlob: Bad inner integrity");
+                    throw new Exception("SensitiveFromDupBlob: Bad inner integrity");
                 }
 
                 sensNoLen = Marshaller.Tpm2BToBuffer(sensitive);

--- a/TSS.NET/TSS.Net/Globs.cs
+++ b/TSS.NET/TSS.Net/Globs.cs
@@ -138,9 +138,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 8)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost8: Wrong input buffer length " + x.Length);
-                if (x.Length < 8)
-                    x = AddZeroToEnd(x, 8 - x.Length);
+                throw new ArgumentException("Globs.NetToHost8: Wrong input buffer length " + x.Length);
             }
             return x[7] + (x[6] << 8) + (x[5] << 16) + (x[4] << 24) +
                    (x[3] << 32) + (x[2] << 40) + (x[1] << 48) + (x[0] << 56);
@@ -150,9 +148,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 8)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost8U: Wrong input buffer length " + x.Length);
-                if (x.Length < 8)
-                    x = AddZeroToEnd(x, 8 - x.Length);
+                throw new ArgumentException("Globs.NetToHost8U: Wrong input buffer length " + x.Length);
             }
             return x[7] + ((ulong)x[6] << 8) + ((ulong)x[5] << 16) + ((ulong)x[4] << 24) +
                    ((ulong)x[3] << 32) + ((ulong)x[2] << 40) + ((ulong)x[1] << 48) + ((ulong)x[0] << 56);
@@ -162,9 +158,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 4)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost4: Wrong input buffer length " + x.Length);
-                if (x.Length < 4)
-                    x = AddZeroToEnd(x, 4 - x.Length);
+                throw new ArgumentException("Globs.NetToHost4: Wrong input buffer length " + x.Length);
             }
             return x[3] + (x[2] << 8) + (x[1] << 16) + (x[0] << 24);
         }
@@ -173,9 +167,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 4)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost4U: Wrong input buffer length " + x.Length);
-                if (x.Length < 4)
-                    x = AddZeroToEnd(x, 4 - x.Length);
+                throw new ArgumentException("Globs.NetToHost4U: Wrong input buffer length " + x.Length);
             }
             return x[3] + (uint)(x[2] << 8) + (uint)(x[1] << 16) + (uint)(x[0] << 24);
         }
@@ -184,9 +176,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 2)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost2: Wrong input buffer length " + x.Length);
-                if (x.Length < 2)
-                    x = AddZeroToEnd(x, 2 - x.Length);
+                throw new ArgumentException("Globs.NetToHost2: Wrong input buffer length " + x.Length);
             }
             return (short)(x[1] + (x[0] << 8));
         }
@@ -195,9 +185,7 @@ namespace Tpm2Lib
         {
             if (x.Length != 2)
             {
-                Globs.Throw<ArgumentException>("Globs.NetToHost2U: Wrong input buffer length " + x.Length);
-                if (x.Length < 2)
-                    x = AddZeroToEnd(x, 2 - x.Length);
+                throw new ArgumentException("Globs.NetToHost2U: Wrong input buffer length " + x.Length);
             }
             return (ushort)(x[1] + (x[0] << 8));
         }
@@ -212,8 +200,7 @@ namespace Tpm2Lib
             {
                 return NetToHost4U(x);
             }
-            Globs.Throw<ArgumentException>("Globs.NetToHostVar(): Unsupported array length " + x.Length);
-            return NetToHost4U(x);
+            throw new ArgumentException("Globs.NetToHostVar(): Unsupported array length " + x.Length);
         }
 
         public static object NetToHostValue(Type t, byte[] data)
@@ -251,8 +238,7 @@ namespace Tpm2Lib
                 return (sbyte)data[0];
             }
             // Unsupported type
-            Globs.Throw<ArgumentException>("Globs.NetToHostValue(): Unsupported type " + t);
-            return 0;
+            throw new ArgumentException("Globs.NetToHostValue(): Unsupported type " + t);
         }
 
         public static object FromBytes(Type t, byte[] data)
@@ -292,8 +278,7 @@ namespace Tpm2Lib
                 return (sbyte)data[0];
             }
             // Unsupported type
-            Globs.Throw<ArgumentException>("Globs.FromBytes(): Unsupported type " + t);
-            return 0;
+            throw new ArgumentException("Globs.FromBytes(): Unsupported type " + t);
         }
 
         public static int SizeOf(Type t)
@@ -317,8 +302,7 @@ namespace Tpm2Lib
                 return sizeof(ulong);
             }
             // Unsupported type
-            Globs.Throw<ArgumentException>("Globs.SizeOf(): Unsupported type " + t);
-            return 0;
+            throw new ArgumentException("Globs.SizeOf(): Unsupported type " + t);
         }
 
         public static ulong GetEnumValue (Enum e)
@@ -534,8 +518,7 @@ namespace Tpm2Lib
             }
             if (String.IsNullOrEmpty(s.ToString()))
             {
-                Globs.Throw<ArgumentException>("HexFromValueType: Unsupported ValueType conversion");
-                s.AppendFormat("{0:X16}", (UInt32)x);
+                throw new ArgumentException("HexFromValueType: Unsupported ValueType conversion");
             }
             return s.ToString();
         }
@@ -600,8 +583,7 @@ namespace Tpm2Lib
             {
                 return 10 + Char.ToLower(c) - 'a';
             }
-            Globs.Throw<ArgumentException>("Character + " + c + "is not hex");
-            return 0;
+            throw new ArgumentException("Character + " + c + "is not hex");
         }
 
         public static bool BigEndianArraysAreEqual(byte[] a1, byte[] a2)
@@ -730,8 +712,7 @@ namespace Tpm2Lib
             {
                 return 8;
             }
-            Globs.Throw<ArgumentException>("GetSizeOfValueType: Unrecognized value type");
-            return 0;
+            throw new ArgumentException("GetSizeOfValueType: Unrecognized value type");
         }
 
         public static T[] Concatenate<T>(T[][] fragments)
@@ -763,8 +744,7 @@ namespace Tpm2Lib
         {
             if (numBits > 7)
             {
-                Globs.Throw<ArgumentException>("ShiftRightInternal: Can only shift up to 7 bits");
-                numBits = 0;
+                throw new ArgumentException("ShiftRightInternal: Can only shift up to 7 bits");
             }
             int numCarryBits = 8 - numBits;
             var y = new byte[x.Length];
@@ -895,8 +875,7 @@ namespace Tpm2Lib
                 case 4: return typeof(UInt32);
                 case 8: return typeof(UInt64);
             }
-            Globs.Throw<ArgumentException>("GetLengthType: Unsupported length size " + lengthSize);
-            return typeof(UInt64);
+            throw new ArgumentException("GetLengthType: Unsupported length size " + lengthSize);
         }
 
         public static string ToCSharpStyle (string typeName)
@@ -1072,28 +1051,6 @@ namespace Tpm2Lib
             return enc == null ? File.ReadAllLines(fileName)
                                : File.ReadAllLines(fileName, enc);
 #endif
-        }
-
-        //
-        // Exception handling helpers
-        //
-
-        public static void Throw<E>(string exceptionMsg) where E : Exception
-        {
-            if (!Tpm2._TssBehavior.Passthrough)
-            {
-                throw Activator.CreateInstance(typeof(E), exceptionMsg) as E;
-            }
-        }
-
-        public static void Throw<E>(string failedFunction, int errorCode) where E : Exception
-        {
-            Throw<E>(failedFunction + " failed: 0x" + errorCode.ToString("X"));
-        }
-
-        public static void Throw(string exceptionMsg)
-        {
-            Throw<Exception>(exceptionMsg);
         }
 
         public static void Free(ref IntPtr ptr)

--- a/TSS.NET/TSS.Net/Marshaller.cs
+++ b/TSS.NET/TSS.Net/Marshaller.cs
@@ -84,10 +84,7 @@ namespace Tpm2Lib
             var len = m.Get<ushort>();
             if (len != x.Length - 2)
             {
-                Globs.Throw<ArgumentException>("Tpm2BToBuffer: Ill formed TPM2B");
-                if (x.Length < 2)
-                    return new byte[0];
-                len = (ushort)(x.Length - 2);
+                throw new ArgumentException("Tpm2BToBuffer: Ill formed TPM2B");
             }
             var ret = new byte[len];
             Array.Copy(x, 2, ret, 0, len);
@@ -233,8 +230,7 @@ namespace Tpm2Lib
                 }
                 else
                 {
-                    Globs.Throw<ArgumentException>("PutInternal: Unsupported enum type");
-                    ToNetValueType(0, name);
+                    throw new ArgumentException("PutInternal: Unsupported enum type");
                 }
             }
             else if (o is ValueType)
@@ -254,7 +250,7 @@ namespace Tpm2Lib
             }
             else
             {
-                Globs.Throw<NotImplementedException>("PutInternal: Unsupported object type");
+                throw new NotImplementedException("PutInternal: Unsupported object type");
             }
 
             if (measuringElement)
@@ -290,8 +286,7 @@ namespace Tpm2Lib
                 Object o = FromNetValueType(tp);
                 return o;
             }
-            Globs.Throw<NotImplementedException>("Get: Not supported type " + tp);
-            return Activator.CreateInstance(tp);
+            throw new NotImplementedException("Get: Not supported type " + tp);
         }
 
         public T Get<T>()
@@ -353,7 +348,7 @@ namespace Tpm2Lib
             {
                 Buffer.Append(Globs.GetBytes(o));
             }
-            Globs.Throw("ToNetValueType: Unsupported marshaling type " + Repr);
+            throw new Exception("ToNetValueType: Unsupported marshaling type " + Repr);
         }
 
         public void PushLength(int numBytes)
@@ -376,9 +371,7 @@ namespace Tpm2Lib
                     ToNet((ulong)0xFFFFFFFFFFFFFFFF);
                     return;
                 default:
-                    Globs.Throw<ArgumentException>("PushLength: Invalid length " + numBytes);
-                    ToNet((ulong)0xFFFFFFFFFFFFFFFF);
-                    return;
+                    throw new ArgumentException("PushLength: Invalid length " + numBytes);
             }
         }
 
@@ -399,9 +392,7 @@ namespace Tpm2Lib
                     Buffer.SetBytesInMiddle(Globs.HostToNet((ulong)len), sp.StartPos);
                     return;
                 default:
-                    Globs.Throw<ArgumentException>("PopAndSetLengthImpl: Invalid length " + sp.Length);
-                    Buffer.SetBytesInMiddle(Globs.HostToNet((ulong)len), sp.StartPos);
-                    return;
+                    throw new ArgumentException("PopAndSetLengthImpl: Invalid length " + sp.Length);
             }
         }
         public void PopAndSetLength()

--- a/TSS.NET/TSS.Net/Policy.cs
+++ b/TSS.NET/TSS.Net/Policy.cs
@@ -104,14 +104,14 @@ namespace Tpm2Lib
                     // Repeats are illegal
                     if (aces.Contains(ace))
                     {
-                        Globs.Throw<ArgumentException>("CreateNormalizedPolicy: " + 
+                        throw new ArgumentException("CreateNormalizedPolicy: " + 
                                                        "Repeated ACE in policy");
                     }
 
                     // Already associated with a session is illegal
                     if (ace.AssociatedPolicy != null)
                     {
-                        Globs.Throw<ArgumentException>("CreateNormalizedPolicy: " +
+                        throw new ArgumentException("CreateNormalizedPolicy: " +
                                             "ACE is already associated with a policy");
                     }
 
@@ -122,7 +122,7 @@ namespace Tpm2Lib
                     // at the root to union the arrays that are input to this function).
                     if (ace is TpmPolicyOr)
                     {
-                        Globs.Throw<ArgumentException>("CreateNormalizedPolicy: " + 
+                        throw new ArgumentException("CreateNormalizedPolicy: " + 
                                             "Normalized form cannot contain TpmPolicyOr");
                     }
 
@@ -140,7 +140,7 @@ namespace Tpm2Lib
                     {
                         if (branchIdDict.ContainsKey(branchId))
                         {
-                            Globs.Throw<ArgumentException>("CreateNormalizedPolicy: " + 
+                            throw new ArgumentException("CreateNormalizedPolicy: " + 
                                             "Repeated branch-identifier " + branchId);
                         }
                         branchIdDict.Add(branchId, "");
@@ -323,12 +323,12 @@ namespace Tpm2Lib
 
                 if (String.IsNullOrEmpty(ace.BranchID))
                 {
-                    Globs.Throw("CheckPolicyIdInternal: Branch leaf does not have a BranchID");
+                    throw new Exception("CheckPolicyIdInternal: Branch leaf does not have a BranchID");
                 }
 
                 if (BranchIdCollection.Contains(ace.BranchID))
                 {
-                    Globs.Throw("CheckPolicyIdInternal: Replicated BranchID " + ace.BranchID);
+                    throw new Exception("CheckPolicyIdInternal: Replicated BranchID " + ace.BranchID);
                 }
 
                 BranchIdCollection.Add(ace.BranchID);
@@ -390,8 +390,7 @@ namespace Tpm2Lib
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("PolicyTree.Serialize: Unknown format " + format);
-                    break;
+                    throw new ArgumentException("PolicyTree.Serialize: Unknown format " + format);
             }
             targetStream.Flush();
         }
@@ -419,8 +418,7 @@ namespace Tpm2Lib
                     break;
                 }
                 default:
-                    Globs.Throw<ArgumentException>("PolicyTree.Deserialize: Unknown format " + format);
-                    return;
+                    throw new ArgumentException("PolicyTree.Deserialize: Unknown format " + format);
             }
             pol.AssociatedPolicy = this;
             PolicyRoot = pol.PolicyRoot;
@@ -494,9 +492,7 @@ namespace Tpm2Lib
         {
             if (SignerCallback == null)
             {
-                Globs.Throw("No policy signer callback installed.");
-                verificationKey = new TpmPublic();
-                return null;
+                throw new Exception("No policy signer callback installed.");
             }
 
             return SignerCallback(this, ace, nonceTpm, out verificationKey);
@@ -541,11 +537,7 @@ namespace Tpm2Lib
         {
             if (PolicyNVCallback == null)
             {
-                Globs.Throw("No policyNV callback installed.");
-                authHandle = new TpmHandle();
-                nvHandle = new TpmHandle();
-                authSession = new AuthSession(new TpmHandle());
-                return;
+                throw new Exception("No policyNV callback installed.");
             }
             PolicyNVCallback(this, ace, out authSession, out authHandle, out nvHandle);
         }
@@ -567,8 +559,7 @@ namespace Tpm2Lib
         {
             if (PolicyActionCallback == null)
             {
-                Globs.Throw("No policyAction callback installed.");
-                return;
+                throw new Exception("No policyAction callback installed.");
             }
             PolicyActionCallback(this, ace);
         }
@@ -675,7 +666,7 @@ namespace Tpm2Lib
             {
                 if (PolicyHash == null)
                 {
-                    Globs.Throw("TpmPolicy.PolicyDigest: No hash algorithm");
+                    throw new Exception("TpmPolicy.PolicyDigest: No hash algorithm");
                 }
                 PolicyHash.HashData = Globs.CopyData(value);
             }

--- a/TSS.NET/TSS.Net/PolicyAces.cs
+++ b/TSS.NET/TSS.Net/PolicyAces.cs
@@ -66,12 +66,12 @@ namespace Tpm2Lib
         {
             if (this is TpmPolicyOr)
             {
-                Globs.Throw<ArgumentException>("AddNextAce: Do not call AddNextAce for " +
+                throw new ArgumentException("AddNextAce: Do not call AddNextAce for " +
                                                "an OR node. Use AddPolicyBranch instead.");
             }
             if (NextAce != null)
             {
-                Globs.Throw<ArgumentException>("AddNextAce: Policy ACE already has a child");
+                throw new ArgumentException("AddNextAce: Policy ACE already has a child");
             }
             if (!String.IsNullOrEmpty(BranchID))
             {
@@ -81,7 +81,7 @@ namespace Tpm2Lib
                 }
                 else if (nextAce.BranchID != BranchID)
                 {
-                    Globs.Throw<ArgumentException>(
+                    throw new ArgumentException(
                                 "AddNextAce: Policy ACE with non-empty BranchName " +
                                 "can only have a child with the same or no branch name");
                 }
@@ -103,7 +103,7 @@ namespace Tpm2Lib
             {
                 if (String.IsNullOrEmpty(BranchID))
                 {
-                    Globs.Throw("GetNextAcePolicyDigest: Policy tree leaf must have a " +
+                    throw new Exception("GetNextAcePolicyDigest: Policy tree leaf must have a " +
                                 "BranchIdentifier set to allow the policy to be evaluated");
                 }
                 return TpmHash.ZeroHash(hashAlg);
@@ -267,7 +267,7 @@ namespace Tpm2Lib
             int numBranches = PolicyBranches.Count;
             if (numBranches < 2 || numBranches > 8)
             {
-                Globs.Throw("GetPolicyHashArray: Must have between 2 and 8 branches in a PolicyOr");
+                throw new Exception("GetPolicyHashArray: Must have between 2 and 8 branches in a PolicyOr");
             }
 
             int i = 0;
@@ -285,7 +285,7 @@ namespace Tpm2Lib
             int numBranches = PolicyBranches.Count;
             if (numBranches < 2 || numBranches > 8)
             {
-                Globs.Throw("GetPolicyDigest: Must have between 2 and 8 branches in a PolicyOr");
+                throw new Exception("GetPolicyDigest: Must have between 2 and 8 branches in a PolicyOr");
             }
 
             var m = new Marshaller();
@@ -717,14 +717,12 @@ namespace Tpm2Lib
 
         internal override TpmHash GetPolicyDigest(TpmAlgId hashAlg)
         {
-            Globs.Throw("Do not include PolicyRestart in policy trees.");
-            return new TpmHash(hashAlg);
+            throw new Exception("Do not include PolicyRestart in policy trees.");
         }
 
         internal override TpmRc Execute(Tpm2 tpm, AuthSession sess, PolicyTree policy)
         {
-            Globs.Throw("Do not include PolicyRestart in running policies");
-            return TpmRc.Policy;
+            throw new Exception("Do not include PolicyRestart in running policies");
         }
     } // class TpmPolicyRestart
 
@@ -990,8 +988,7 @@ namespace Tpm2Lib
                 commandCode = TpmCc.PolicySigned;
             else
             {
-                Globs.Throw<ArgumentException>("Ticket type is not recognized");
-                return new TpmHash(hashAlg);
+                throw new ArgumentException("Ticket type is not recognized");
             }
 
             if (ObjectName == null)
@@ -1213,8 +1210,7 @@ namespace Tpm2Lib
         {
             if (NextAce != null)
             {
-                Globs.Throw("PolicyChainId should be a leaf");
-                return new TpmHash(hashAlg);
+                throw new Exception("PolicyChainId should be a leaf");
             }
             return GetNextAcePolicyDigest(hashAlg);
         }

--- a/TSS.NET/TSS.Net/Sessions.cs
+++ b/TSS.NET/TSS.Net/Sessions.cs
@@ -197,7 +197,7 @@ namespace Tpm2Lib
         {
             if (!h.IsSession())
             {
-                Globs.Throw<ArgumentException>("AuthSession: Attempt to construct from non-session handle");
+                throw new ArgumentException("AuthSession: Attempt to construct from non-session handle");
             }
             Handle = h;
         }
@@ -211,7 +211,7 @@ namespace Tpm2Lib
         {
             if (ph.Handle != TpmRh.None && !ph.Handle.IsSession())
             {
-                Globs.Throw<ArgumentException>("AuthSession: Attempt to construct from parametrized non-session handle");
+                throw new ArgumentException("AuthSession: Attempt to construct from parametrized non-session handle");
             }
             Handle = ph.Handle;
             foreach(object param in ph.Params)
@@ -226,7 +226,7 @@ namespace Tpm2Lib
                 }
                 else if (param != null)
                 {
-                    Globs.Throw<ArgumentException>("AuthSession: Attempt to construct from malformed parametrized handle");
+                    throw new ArgumentException("AuthSession: Attempt to construct from malformed parametrized handle");
                 }
             }
         }
@@ -302,8 +302,7 @@ namespace Tpm2Lib
         {
             if (Symmetric == null)
             {
-                Globs.Throw("parameter encryption cipher not defined");
-                return parm;
+                throw new Exception("parameter encryption cipher not defined");
             }
             if (Symmetric.Algorithm == TpmAlgId.Null)
             {
@@ -357,7 +356,7 @@ namespace Tpm2Lib
         {
             if (Salt == SaltNeeded)
             {
-                Globs.Throw("Unencrypted salt value must be provided for the session" +
+                throw new Exception("Unencrypted salt value must be provided for the session" +
                             Handle.handle.ToString("X8"));
             }
 
@@ -450,7 +449,7 @@ namespace Tpm2Lib
             policyTree.CheckPolicy(branchToEvaluate, ref leafAce);
             if (leafAce == null)
             {
-                Globs.Throw("RunPolicy: Branch identifier " + branchToEvaluate + " does not exist");
+                throw new Exception("RunPolicy: Branch identifier " + branchToEvaluate + " does not exist");
             }
 
             var responseCode = TpmRc.Success;

--- a/TSS.NET/TSS.Net/SupportClasses.cs
+++ b/TSS.NET/TSS.Net/SupportClasses.cs
@@ -81,10 +81,7 @@ namespace Tpm2Lib
         {
             if (pos + bytesToSet.Length > GetSize())
             {
-                Globs.Throw<ArgumentOutOfRangeException>("Position is not in allocated buffer");
-                if (GetSize() > pos)
-                    Array.Copy(bytesToSet, 0, Buf, pos, GetSize() - pos);
-                return;
+                throw new ArgumentOutOfRangeException("Position is not in allocated buffer");
             }
             Array.Copy(bytesToSet, 0, Buf, pos, bytesToSet.Length);
         }
@@ -128,9 +125,7 @@ namespace Tpm2Lib
         {
             if (newGetPos < 0 || newGetPos > GetSize())
             {
-                Globs.Throw("SetGetPos: Invalid position");
-                GetPos = newGetPos < 0 ? 0 : GetSize();
-                return;
+                throw new Exception("SetGetPos: Invalid position");
             }
             GetPos = newGetPos;
         }
@@ -139,9 +134,8 @@ namespace Tpm2Lib
         {
             if (GetPos + num > PutPos)
             {
-                Globs.Throw<ArgumentOutOfRangeException>("ByteBuf exception removing "
+                throw new ArgumentOutOfRangeException("ByteBuf exception removing "
                     + num + " bytes at position " + GetPos + " from an array of " + PutPos);
-                return null;
             }
             var ret = new byte[num];
             Array.Copy(Buf, GetPos, ret, 0, num);
@@ -236,8 +230,7 @@ namespace Tpm2Lib
         {
             if (numBytes > RandMaxBytes)
             {
-                Globs.Throw<ArgumentException>("GetRandomBytes: Too many bytes requested " + numBytes);
-                numBytes = RandMaxBytes;
+                throw new ArgumentException("GetRandomBytes: Too many bytes requested " + numBytes);
             }
             // Make sure that the RNG is properly seeded
             if (Seed == null)
@@ -485,7 +478,7 @@ namespace Tpm2Lib
                     return;
                 }
             }
-            Globs.Throw<NotImplementedException>("Print: Unknown type " + o.GetType());
+            throw new NotImplementedException("Print: Unknown type " + o.GetType());
         }
 
         private string Spaces()

--- a/TSS.NET/TSS.Net/TSS.Net.csproj
+++ b/TSS.NET/TSS.Net/TSS.Net.csproj
@@ -11,7 +11,7 @@
     <!-- Don't attempt to target .NET 5 from older Visual Studio / MSBuild versions -->
     <When Condition="$(VisualStudioVersion) &lt; '16.0'">
       <PropertyGroup>
-        <TargetFrameworks>net472</TargetFrameworks>
+        <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
       </PropertyGroup>
     </When>
     <Otherwise>

--- a/TSS.NET/TSS.Net/Tpm2.cs
+++ b/TSS.NET/TSS.Net/Tpm2.cs
@@ -1152,8 +1152,7 @@ namespace Tpm2Lib
 
                 if (CommandAuditHash == null)
                 {
-                    Globs.Throw("No audit hash set for this command stream");
-                    CommandAuditHash = TpmAlgId.None;
+                    throw new Exception("No audit hash set for this command stream");
                 }
                 byte[] parmHash = GetCommandHash(CommandAuditHash.HashAlg, parms, inHandles);
                 byte[] expectedResponseHash = GetExpectedResponseHash(CommandAuditHash.HashAlg,
@@ -1568,7 +1567,7 @@ namespace Tpm2Lib
             // If the load-command fails then the name returned is NULL.
             if (!NamesEqual(publicPart.GetName(), tpmAssignedName))
             {
-                Globs.Throw("TPM assigned name differs from what is expected");
+                throw new Exception("TPM assigned name differs from what is expected");
             }
             h.Name = tpmAssignedName;
         }
@@ -1822,7 +1821,7 @@ namespace Tpm2Lib
                 {
                     // There are no session parameters associated with the session
                     // handle (e.g., when the session was created by other Tpm2 object).
-                    Globs.Throw("Wrong session handle");
+                    throw new Exception("Wrong session handle");
                 }
                 s.AuthHandle = authHandle;
             }
@@ -1929,7 +1928,7 @@ namespace Tpm2Lib
                 }
                 else
                 {
-                    Globs.Throw("CreateRequestSessions: Unknown session type");
+                    throw new Exception("CreateRequestSessions: Unknown session type");
                 }
                 firstSession = false;
             }
@@ -2006,7 +2005,7 @@ namespace Tpm2Lib
                     {
                         if (!Globs.ArraysAreEqual(outSess.auth, expectedHmac))
                         {
-                            //Globs.Throw<TpmFailure>("Bad response HMAC");
+                            //throw new TpmFailure("Bad response HMAC");
                             throw new TpmFailure("Bad response HMAC");
                         }
                     }
@@ -2060,12 +2059,12 @@ namespace Tpm2Lib
 
             if (!candidate.CanEncrypt())
             {
-                Globs.Throw(string.Format("{0} session is missing symmetric algorithm",
+                throw new Exception(string.Format("{0} session is missing symmetric algorithm",
                                           decrypt ? "Decryption" : "Encryption"));
             }
             if ((decrypt ? DecSession : EncSession) != null)
             {
-                Globs.Throw(string.Format("Multiple {0} sessions",
+                throw new Exception(string.Format("Multiple {0} sessions",
                                           decrypt ? "decryption" : "encryption"));
             }
             if (decrypt)
@@ -2115,10 +2114,9 @@ namespace Tpm2Lib
             }
             if ((commandInfo.TheParmCryptInfo & (encFlag2 | encFlag4)) == 0)
             {
-                Globs.Throw(string.Format("Command {0} cannot use {1} session",
+                throw new Exception(string.Format("Command {0} cannot use {1} session",
                                           commandInfo.CommandCode,
                                           inOrOut == Direction.Command ? "decryption" : "encryption"));
-                return parms;
             }
 
             // ... and get the length of the size counter prepending the XCrypted parameter.
@@ -2660,8 +2658,7 @@ namespace Tpm2Lib
             commandParms = m.GetArray<byte>((int)(m.GetPutPos() - m.GetGetPos()));
             if (m.GetPutPos() != header.CommandSize)
             {
-                Globs.Throw("Command length in header does not match input byte-stream");
-                return false;
+                throw new Exception("Command length in header does not match input byte-stream");
             }
             return true;
         }
@@ -2951,8 +2948,7 @@ namespace Tpm2Lib
                         encOutParms = m2.Get(typeof (Tpm2bMaxBuffer), "");
                         break;
                     default:
-                        Globs.Throw<NotImplementedException>("NOT IMPLEMENTED");
-                        break;
+                        throw new NotImplementedException("NOT IMPLEMENTED");
                 }
                 response += "Encrypted: " + encOutParms + "\n";
             }

--- a/TSS.NET/TSS.Net/Tpm2Abstractions.cs
+++ b/TSS.NET/TSS.Net/Tpm2Abstractions.cs
@@ -137,9 +137,7 @@ namespace Tpm2Lib
             TaggedProperty[] arr = props.tpmProperty;
             if (arr.Length != 1)
             {
-                Globs.Throw("Unexpected return from GetCapability");
-                if (arr.Length == 0)
-                    return 0;
+                throw new Exception("Unexpected return from GetCapability");
             }
 
             uint val = arr[0].value;
@@ -157,7 +155,7 @@ namespace Tpm2Lib
             }
             if (props.Length != 1)
             {
-                Globs.Throw("Unexpected return from GetCapability");
+                throw new Exception("Unexpected return from GetCapability");
             }
             return props[0].pcrSelect;
         }

--- a/TSS.NET/TSS.Net/Tpm2Helpers.cs
+++ b/TSS.NET/TSS.Net/Tpm2Helpers.cs
@@ -100,7 +100,7 @@ namespace Tpm2Lib
             if (   !Enum.TryParse<E>(newName, out val)
                 && !Enum.TryParse<E>(oldName, out val))
             {
-                Globs.Throw("Invalid enumerator names " + oldName + ", "
+                throw new Exception("Invalid enumerator names " + oldName + ", "
                             + newName + " for enum " + typeof(E));
             }
             return val;

--- a/TSS.NET/TSS.Net/TpmCustomDefs.cs
+++ b/TSS.NET/TSS.Net/TpmCustomDefs.cs
@@ -30,7 +30,7 @@ namespace Tpm2Lib
             {
                 if (!CryptoLib.IsHashAlgorithm(value) && Tpm2._TssBehavior.Strict)
                 {
-                    Globs.Throw<ArgumentException>("TpmHash.HashAlg: Invalid hash alg ID");
+                    throw new ArgumentException("TpmHash.HashAlg: Invalid hash alg ID");
                 }
                 hashAlg = value;
                 digest = new byte[CryptoLib.DigestSize(hashAlg)];
@@ -47,7 +47,7 @@ namespace Tpm2Lib
             {
                 if (digest.Length != CryptoLib.DigestSize(hashAlg))
                 {
-                    Globs.Throw("TpmHash.HashData: Inconsistent data length");
+                    throw new Exception("TpmHash.HashData: Inconsistent data length");
                 }
                 return digest;
             }
@@ -55,7 +55,7 @@ namespace Tpm2Lib
             {
                 if (value.Length != Length)
                 {
-                    Globs.Throw<ArgumentException>("TpmHash.HashData: Incorrect data length");
+                    throw new ArgumentException("TpmHash.HashData: Incorrect data length");
                 }
                 digest = Globs.CopyData(value);
             }
@@ -92,7 +92,7 @@ namespace Tpm2Lib
             HashAlg = hashAlg;
             if (Length != digest.Length)
             {
-                Globs.Throw<ArgumentException>("TpmHash: Incorrect digest length");
+                throw new ArgumentException("TpmHash: Incorrect digest length");
             }
             digest.CopyTo(digest, 0);
         }
@@ -220,7 +220,7 @@ namespace Tpm2Lib
         {
             if (!CryptoLib.IsHashAlgorithm(hashAlg))
             {
-                Globs.Throw<ArgumentException>("TpmHash.FromData: Not a hash algorithm");
+                throw new ArgumentException("TpmHash.FromData: Not a hash algorithm");
             }
             return new TpmHash(hashAlg, CryptoLib.HashData(hashAlg, dataToHash));
         }
@@ -234,7 +234,7 @@ namespace Tpm2Lib
         {
             if (!CryptoLib.IsHashAlgorithm(hashAlg))
             {
-                Globs.Throw<ArgumentException>("TpmHash.FromRandom: Not a hash algorithm");
+                throw new ArgumentException("TpmHash.FromRandom: Not a hash algorithm");
             }
             return new TpmHash(hashAlg, CryptoLib.HashData(hashAlg, Globs.GetRandomBytes(
                                                                     (int)DigestSize(hashAlg))));
@@ -250,7 +250,7 @@ namespace Tpm2Lib
         {
             if (!CryptoLib.IsHashAlgorithm(hashAlg))
             {
-                Globs.Throw<ArgumentException>("TpmHash.FromString: Not a hash algorithm");
+                throw new ArgumentException("TpmHash.FromString: Not a hash algorithm");
             }
             return new TpmHash(hashAlg, CryptoLib.HashData(hashAlg, Encoding.Unicode.GetBytes(message)));
         }
@@ -1260,7 +1260,7 @@ namespace Tpm2Lib
                     // Do we already have a PcrValue with the same {alg, pcrNum?}
                     if (selection[bankNum].IsPcrSelected(val.index))
                     {
-                        Globs.Throw("PcrValueCollection.GetPcrSelectionArray: PCR is referenced more than once");
+                        throw new Exception("PcrValueCollection.GetPcrSelectionArray: PCR is referenced more than once");
                     }
                     // Else select it
                     selection[bankNum].SelectPcr(val.index);
@@ -1312,8 +1312,7 @@ namespace Tpm2Lib
                     return v;
                 }
             }
-            Globs.Throw("PcrValueCollection.GetSpecificValue: PCR not found");
-            return new PcrValue();
+            throw new Exception("PcrValueCollection.GetSpecificValue: PCR not found");
         }
     }
 
@@ -1352,10 +1351,7 @@ namespace Tpm2Lib
                     m.Put(Mode, "mode");
                     break;
                 default:
-                    Globs.Throw<NotImplementedException>("SymDef.ToNet: Unknown algorithm");
-                    m.Put(KeyBits, "keyBits");
-                    m.Put(Mode, "mode");
-                    break;
+                    throw new NotImplementedException("SymDef.ToNet: Unknown algorithm");
             }
         }
 
@@ -1377,10 +1373,7 @@ namespace Tpm2Lib
                     Mode = m.Get<TpmAlgId>();
                     break;
                 default:
-                    Globs.Throw<NotImplementedException>("SymDef.ToHost: Unknown algorithm");
-                    KeyBits = m.Get<ushort>();
-                    Mode = m.Get<TpmAlgId>();
-                    break;
+                    throw new NotImplementedException("SymDef.ToHost: Unknown algorithm");
             }
         }
     } // class SymDef
@@ -1430,7 +1423,7 @@ namespace Tpm2Lib
         {
             if (Algorithm == TpmAlgId.Xor)
             {
-                Globs.Throw<NotImplementedException>("SymDefObject.ToNet: XOR is not supported");
+                throw new NotImplementedException("SymDefObject.ToNet: XOR is not supported");
             }
             m.Put(Algorithm, "algorithm");
             if (Algorithm == TpmAlgId.None || Algorithm == TpmAlgId.Null)

--- a/TSS.NET/TSS.Net/TpmDevices.cs
+++ b/TSS.NET/TSS.Net/TpmDevices.cs
@@ -637,7 +637,7 @@ namespace Tpm2Lib
             GetAck(PlatformStream, "ActGetSignaled");
 
             if ((uint)status > 1)
-                Globs.Throw($"ActGetSignaled: invalid response '{status}' receieved (0 or 1 expected)");
+                throw new Exception($"ActGetSignaled: invalid response '{status}' receieved (0 or 1 expected)");
             return status == 1;
         }
 

--- a/TSS.NET/TSS.Net/TpmKey.cs
+++ b/TSS.NET/TSS.Net/TpmKey.cs
@@ -339,10 +339,8 @@ namespace Tpm2Lib
                     encSecret = Marshaller.GetTpmRepresentation(ephemPubPt);
                     break;
                 default:
-                    Globs.Throw<NotImplementedException>(
+                    throw new NotImplementedException(
                                 "CreateActivationCredentials: Unsupported algorithm");
-                    encryptedSecret = new byte[0];
-                    return null;
             }
 
             Transform(seed);
@@ -444,9 +442,8 @@ namespace Tpm2Lib
 
             if (Public.type != TpmAlgId.Symcipher)
             {
-                Globs.Throw<ArgumentException>("Only symmetric encryption/decryption is "
+                throw new ArgumentException("Only symmetric encryption/decryption is "
                                              + "supported by this overloaded version");
-                return null;
             }
 
             var symDef = GetSymDef();
@@ -455,8 +452,7 @@ namespace Tpm2Lib
             {
                 if (sym == null)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported symmetric key configuration");
-                    return null;
+                    throw new ArgumentException("Unsupported symmetric key configuration");
                 }
 
                 if (Globs.IsEmpty(ivIn))
@@ -679,10 +675,8 @@ namespace Tpm2Lib
                     encSecret = Marshaller.GetTpmRepresentation(pubEphem);
                     break;
                 default:
-                    Globs.Throw<NotImplementedException>(
+                    throw new NotImplementedException(
                                         "GetDuplicationBlob: Unsupported algorithm");
-                    encSecret = new byte[0];
-                    return new TpmPrivate();
                 }
             }
             Transform(seed);
@@ -762,8 +756,7 @@ namespace Tpm2Lib
                 var symDef = (SymDefObject)pub.parameters;
                 if (symDef.Algorithm != TpmAlgId.Aes)
                 {
-                    Globs.Throw<ArgumentException>("Unsupported symmetric algorithm");
-                    return null;
+                    throw new ArgumentException("Unsupported symmetric algorithm");
                 }
 
                 int keySize = (symDef.KeyBits + 7) / 8;
@@ -777,8 +770,7 @@ namespace Tpm2Lib
                 }
                 else
                 {
-                    Globs.Throw<ArgumentException>("Wrong symmetric key length");
-                    return null;
+                    throw new ArgumentException("Wrong symmetric key length");
                 }
                 newSens = new Tpm2bSymKey(keyData);
             }
@@ -800,14 +792,13 @@ namespace Tpm2Lib
                 }
                 else
                 {
-                    Globs.Throw<ArgumentException>("HMAC key is too big");
-                    return null;
+                    throw new ArgumentException("HMAC key is too big");
                 }
                 newSens = new Tpm2bSensitiveData(keyData);
             }
             else
             {
-                Globs.Throw<ArgumentException>("Unsupported key type");
+                throw new ArgumentException("Unsupported key type");
             }
 
             return newSens;
@@ -854,8 +845,7 @@ namespace Tpm2Lib
                                         ? (keyParms.parameters as SymcipherParms).sym
                                         : keyParms.parameters as SymDefObject;
                 default:
-                    Globs.Throw("Unsupported key type");
-                    return new SymDefObject();
+                    throw new Exception("Unsupported key type");
             }
         }
 


### PR DESCRIPTION
This change removes the Globs.Throw helpers (which sometimes throw and
sometimes don't) and the unclear control-flow surrounding them (since
we didn't always throw, we had to return garbage values to satisfy the
compiler). `Globs.Throw<X>` is replaced by `throw new X`.

fixes #104