### PR TITLE
Support importing ECC private keys; fix OAEP infinite loop issue

### DIFF
--- a/TSS.NET/TSS.Net/CryptoLib.cs
+++ b/TSS.NET/TSS.Net/CryptoLib.cs
@@ -315,13 +315,10 @@ namespace Tpm2Lib
             return encodedMessage;
         }
 
-        public static bool OaepDecode(byte[] eMx, byte[] encodingParms,
+        public static bool OaepDecode(byte[] em, byte[] encodingParms,
                                       TpmAlgId hashAlg, out byte[] decoded)
         {
             decoded = new byte[0];
-
-            var em = new byte[eMx.Length + 1];
-            Array.Copy(eMx, 0, em, 1, eMx.Length);
 
             int hLen = CryptoLib.DigestSize(hashAlg);
             int k = em.Length;


### PR DESCRIPTION
`AsymCryptoSystem.CreateFrom` supports importing RSA private keys, but not ECC private keys. This change adds the support for that.

Tested by updating some TPM library tests to export TPM ECC private keys for software signing using this function.