### PR TITLE
Fix the Tpm2Tester build

### DIFF
--- a/Tpm2Tester/TestSubstrate/TestSubstrate.cs
+++ b/Tpm2Tester/TestSubstrate/TestSubstrate.cs
@@ -839,8 +839,7 @@ namespace Tpm2Tester
                                         PersRsaPrimPlatform);
                 }
             }
-            Globs.Throw("Handle " + hierarchy + "is not a hierarchy");
-            return null;
+            throw new Exception("Handle " + hierarchy + "is not a hierarchy");
         }
 
         private bool ClearPersistent(Tpm2 tpm, TpmRh hierarchy,
@@ -1202,7 +1201,7 @@ namespace Tpm2Tester
                 }
 
                 if (!nvCleared)
-                    Globs.Throw("Not enough NV to make a primary key persistent");
+                    throw new Exception("Not enough NV to make a primary key persistent");
 
                 // Try to persist the new primary one more time
                 tpm.EvictControl(hierarchy, hPrim, hPers);

--- a/Tpm2Tester/TestSubstrate/TpmConfig.cs
+++ b/Tpm2Tester/TestSubstrate/TpmConfig.cs
@@ -288,8 +288,7 @@ namespace Tpm2Tester
                 if (pb.hash == hashAlg)
                     return pb;
             }
-            Globs.Throw("No PCR bank for hash algorithm " + hashAlg);
-            return null;
+            throw new Exception("No PCR bank for hash algorithm " + hashAlg);
         }
 
     } // class TpmConfig

--- a/Tpm2Tester/TestSubstrate/TpmHelper.cs
+++ b/Tpm2Tester/TestSubstrate/TpmHelper.cs
@@ -41,9 +41,8 @@ namespace Tpm2Tester
                     buf = (pub.unique as Tpm2bDigest).buffer;
                     return pub.unique.GetType().GetField("buffer");
             }
-            Globs.Throw<NotImplementedException>(
+            throw new NotImplementedException(
                                 "GetUniqueBuffer: Unknown TpmPublic type " + keyType);
-            return null;
         }
 
         public static byte[] GetUniqueBuffer(TpmPublic pub)
@@ -352,7 +351,7 @@ namespace Tpm2Tester
             } while (++iter < MaxIter);
 
             if (iter == MaxIter)
-                Globs.Throw("The system is likely overloaded. Cannot do reliable time measurements.");
+                throw new Exception("The system is likely overloaded. Cannot do reliable time measurements.");
 
             //Console.WriteLine("ITER {0}, MEAN {1:F0}->{2:F0}, SD {3:F1}; Good {4}; RATE {5:F2}",
             //                  iter+1, meanSys, sysTime / n, stdDevSys, n, tpmTime / sysTime);


### PR DESCRIPTION
I'm getting errors due to missed method `Globs.Throw`. I did a quick inspection on the repo and looks like `Globs.Throw` methods were delete in this commit: https://github.com/microsoft/TSS.MSR/commit/207eb4ab6136138168c1dd2e704e53617ff94972. After the changes in the PR I can build the Tpm2Tester solution.