### PR TITLE
Move TSSMain into package samples

### DIFF
--- a/TSS.Java/src/samples/TSSMain.java
+++ b/TSS.Java/src/samples/TSSMain.java
@@ -1,3 +1,4 @@
+package samples;
 //import java.util.Arrays;
 
 import samples.CmdLine;


### PR DESCRIPTION
TSS.Java 1.0.0 packages from mvn repository cannot be used together with OSGI projects, as OSGI forbids classes without a package specified.
TSSMain.java does not specify a package and is included in the mvn package.

This leads to the compile error in OSGI projects:
```The default package '.' is not permitted by the Import-Package syntax.```

The workaround is repackaging or unpacking and removing the TSSMain during build.

This PR just moves the TSSMain.java file into the samples package. Could you please include this PR and release?