### PR TITLE
Upgrade dependencies

### DIFF
--- a/TSS.Java/pom.xml
+++ b/TSS.Java/pom.xml
@@ -31,13 +31,13 @@
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.67</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.77</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
       <artifactId>jna</artifactId>
-      <version>4.4.0</version>
+      <version>5.14.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -53,7 +53,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.12.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -95,11 +95,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.6.3</version>
         <configuration>
           <!-- needed to build with JDK 11/12/13 -->
           <source>8</source>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <doclint>all,-missing</doclint>
         </configuration> 
         <executions>
           <execution>


### PR DESCRIPTION
Modernize the build toolchain, include a more recent release of bouncy castle.

- Upgrade bcprov-jdk15on 1.67 to bcprov-jdk18on 1.77 to address CVE-2023-33201 (does not affect TSS.Java itself)
(fixes and current release are no longer available on the jdk15 branch, but only on jdk18 - should be fine for TSS.java as it is configured for 1.8)
- Upgrade net.java.dev.jna from 4.0.4 to 5.14.0, see changelog here: https://github.com/java-native-access/jna/blob/master/CHANGES.md#release-5140
- Upgrade mvn build and javadoc plugin, upgrade deprecated configuration settings