### PR TITLE
Fix PcrIsSelected logic

### DIFF
--- a/TSS.CPP/Src/TpmExtensions.cpp.snips
+++ b/TSS.CPP/Src/TpmExtensions.cpp.snips
@@ -193,7 +193,7 @@ static vector<TPMS_PCR_SELECTION> GetSelectionArray(TPM_ALG_ID hashAlg, UINT32 p
 /// <summary> Is the PCR with index _pcr selected in this TPMS_PCR_SELECTION. </summary>
 bool PcrIsSelected(UINT32 pcr)
 {
-    return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1 != 0;
+    return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1;
 }
 
 /// <summary> Return the current PCR-selection as a UINT32 array. </summary>

--- a/TSS.CPP/Src/TpmExtensions.cpp.snips
+++ b/TSS.CPP/Src/TpmExtensions.cpp.snips
@@ -193,7 +193,7 @@ static vector<TPMS_PCR_SELECTION> GetSelectionArray(TPM_ALG_ID hashAlg, UINT32 p
 /// <summary> Is the PCR with index _pcr selected in this TPMS_PCR_SELECTION. </summary>
 bool PcrIsSelected(UINT32 pcr)
 {
-    return pcrSelect[pcr / 8] = (1 << (pcr % 8)) != 0;
+    return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1 != 0;
 }
 
 /// <summary> Return the current PCR-selection as a UINT32 array. </summary>

--- a/TSS.CPP/include/TpmTypes.h
+++ b/TSS.CPP/include/TpmTypes.h
@@ -3653,7 +3653,7 @@ public:
     /// <summary> Is the PCR with index _pcr selected in this TPMS_PCR_SELECTION. </summary>
     bool PcrIsSelected(UINT32 pcr)
     {
-        return pcrSelect[pcr / 8] = (1 << (pcr % 8)) != 0;
+        return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1 != 0;
     }
 
     /// <summary> Return the current PCR-selection as a UINT32 array. </summary>

--- a/TSS.CPP/include/TpmTypes.h
+++ b/TSS.CPP/include/TpmTypes.h
@@ -3653,7 +3653,7 @@ public:
     /// <summary> Is the PCR with index _pcr selected in this TPMS_PCR_SELECTION. </summary>
     bool PcrIsSelected(UINT32 pcr)
     {
-        return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1 != 0;
+        return (pcrSelect[pcr / 8] >> (pcr % 8)) & 1;
     }
 
     /// <summary> Return the current PCR-selection as a UINT32 array. </summary>


### PR DESCRIPTION
According to TCG Part1 17.5 - 
The bit correspondence to PCR is that the bit corresponding to PCR[n] is the (n mod 8) bit in the ⌊n/8⌋ octet of the array. 

Fix the wrong logic to fit the spec.